### PR TITLE
Project scaffolding — repo structure and devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "Navvi",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/desktop-lite:1": {
+      "password": "navvi",
+      "webPort": "6080",
+      "vncPort": "5901"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  },
+  "forwardPorts": [6080, 5901, 9222],
+  "postCreateCommand": "bash .devcontainer/setup.sh",
+  "remoteEnv": {
+    "DISPLAY": ":1"
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Install Chromium + Playwright deps
+sudo env PATH="$PATH" npx playwright install-deps chromium
+npx playwright install chromium
+
+# Install playwright-core for CDP scripting
+npm install playwright-core
+
+echo "Navvi devcontainer ready."
+echo "  VNC:  http://localhost:6080 (password: navvi)"
+echo "  CDP:  port 9222 (launch Chrome with --remote-debugging-port=9222)"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.navvi/profiles/*/
+package-lock.json

--- a/.navvi/profiles/.gitignore
+++ b/.navvi/profiles/.gitignore
@@ -1,0 +1,3 @@
+# Browser profiles contain cookies and session data — never commit
+*
+!.gitignore

--- a/README.md
+++ b/README.md
@@ -1,1 +1,83 @@
-# navvi
+# Navvi
+
+Agentic browser persona manager. Each persona is a persistent browser identity with its own cookies, credentials, and profile — running in a Codespace with headed Chrome.
+
+Spin up per task. Tear down when done.
+
+## How It Works
+
+```
+Claude Code (brain)
+    ↓
+Navvi (persona + browser orchestration)
+    ↓
+Headed Chrome in Codespace (VNC + CDP)
+    ↓
+Real websites with isTrusted events
+```
+
+## Quick Start
+
+1. Create a Codespace from this repo
+2. Chrome launches with VNC on port 6080, CDP on port 9222
+3. Define personas in `.navvi/personas/*.yml`
+4. Launch a persona: `./scripts/launch-chrome.sh fry-dev`
+
+## Structure
+
+```
+.devcontainer/       # Codespace config (desktop-lite + Chromium)
+.navvi/
+├── personas/        # Persona definitions (YAML, committed)
+└── profiles/        # Browser profiles with cookies (gitignored)
+scripts/
+├── launch-chrome.sh   # Launch headed Chrome for a persona
+├── export-profile.sh  # Tar a profile for backup
+└── import-profile.sh  # Restore a profile from tar
+```
+
+## Persona Definition
+
+```yaml
+# .navvi/personas/fry-dev.yml
+name: fry-dev
+description: Fry's developer persona
+email: ayuda.intro@gmail.com
+credentials: $BW_ENTRY_NAME
+services:
+  - dev.to
+  - github.com
+browser:
+  stealth: true
+  locale: en-US
+  timezone: America/Santiago
+```
+
+## Profile Persistence
+
+Profiles live in `.navvi/profiles/` (gitignored). For backup across Codespace rebuilds:
+
+```bash
+# Export
+./scripts/export-profile.sh fry-dev /tmp/fry-dev-profile.tar.gz
+
+# Import
+./scripts/import-profile.sh /tmp/fry-dev-profile.tar.gz
+```
+
+## Why Headed Chrome?
+
+- `isTrusted=true` mouse/keyboard events — passes CAPTCHA detection
+- OAuth popups, cookie banners, multi-step wizards work naturally
+- VNC gives visual debugging — see what the agent sees
+- Persistent profiles keep you logged in across sessions
+
+## Companion: Flowchad
+
+Navvi is the browser hands. [Flowchad](https://github.com/Fellowship-dev/flowchad) is the QA brain.
+
+Flowchad defines what to test. Navvi handles headed execution when headless won't cut it (CAPTCHAs, OAuth, stealth).
+
+## License
+
+MIT

--- a/scripts/export-profile.sh
+++ b/scripts/export-profile.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Export a persona's browser profile as a tar archive.
+# Usage: ./scripts/export-profile.sh <persona-name> [output-path]
+#
+# For backup/restore across Codespace rebuilds.
+
+PERSONA="${1:?Usage: export-profile.sh <persona-name> [output-path]}"
+PROFILE_DIR="$(pwd)/.navvi/profiles/$PERSONA"
+OUTPUT="${2:-/tmp/$PERSONA-profile.tar.gz}"
+
+if [ ! -d "$PROFILE_DIR" ]; then
+  echo "Error: profile directory not found: $PROFILE_DIR"
+  exit 1
+fi
+
+tar -czf "$OUTPUT" -C ".navvi/profiles" "$PERSONA"
+echo "Exported $PERSONA profile to $OUTPUT ($(du -sh "$OUTPUT" | cut -f1))"

--- a/scripts/import-profile.sh
+++ b/scripts/import-profile.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Import a persona's browser profile from a tar archive.
+# Usage: ./scripts/import-profile.sh <archive-path>
+#
+# Extracts into .navvi/profiles/<persona-name>/
+
+ARCHIVE="${1:?Usage: import-profile.sh <archive-path>}"
+
+if [ ! -f "$ARCHIVE" ]; then
+  echo "Error: archive not found: $ARCHIVE"
+  exit 1
+fi
+
+tar -xzf "$ARCHIVE" -C ".navvi/profiles"
+echo "Imported profile from $ARCHIVE"
+ls -d .navvi/profiles/*/

--- a/scripts/launch-chrome.sh
+++ b/scripts/launch-chrome.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Launch headed Chrome with CDP enabled for a given persona.
+# Usage: ./scripts/launch-chrome.sh [persona-name]
+#
+# Runs in the Codespace with DISPLAY=:1 (VNC).
+# Profile stored in .navvi/profiles/<persona>/
+
+PERSONA="${1:-default}"
+PROFILE_DIR="$(pwd)/.navvi/profiles/$PERSONA"
+mkdir -p "$PROFILE_DIR"
+
+echo "Launching Chrome for persona: $PERSONA"
+echo "  Profile: $PROFILE_DIR"
+echo "  CDP:     http://127.0.0.1:9222"
+
+# Use Playwright's bundled Chromium
+CHROMIUM="$(npx playwright install --dry-run chromium 2>/dev/null | grep -o '/.*chrome' | head -1)"
+if [ -z "$CHROMIUM" ]; then
+  CHROMIUM="$(find "$HOME" -name 'chrome' -path '*/chromium*' -type f 2>/dev/null | head -1)"
+fi
+
+if [ -z "$CHROMIUM" ]; then
+  echo "Error: Chromium not found. Run: npx playwright install chromium"
+  exit 1
+fi
+
+exec "$CHROMIUM" \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$PROFILE_DIR" \
+  --no-first-run \
+  --no-default-browser-check \
+  --disable-sync \
+  --disable-background-networking \
+  --disable-extensions \
+  --start-maximized \
+  "$2"


### PR DESCRIPTION
## Summary
- Devcontainer with desktop-lite (VNC on 6080, CDP on 9222), Chromium via Playwright
- `.navvi/personas/` for YAML persona definitions (committed)
- `.navvi/profiles/` for browser profiles with cookies (gitignored)
- Scripts: `launch-chrome.sh` (CDP + persona profile dir), `export-profile.sh` / `import-profile.sh` (tar backup/restore)
- README with quick start, structure, persona format example
- Spin-up-per-task model, not always-on

Closes #1