### PR TITLE
PinchTab integration — HTTP API bridge

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
       "version": "lts"
     }
   },
-  "forwardPorts": [6080, 5901, 9222],
+  "forwardPorts": [6080, 5901, 9222, 9867],
   "mounts": [
     "source=navvi-profiles,target=${containerWorkspaceFolder}/.navvi/profiles,type=volume"
   ],

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -8,6 +8,11 @@ npx playwright install chromium
 # Install playwright-core for CDP scripting
 npm install playwright-core
 
+# Install PinchTab
+curl -fsSL https://pinchtab.com/install.sh | bash
+
+echo ""
 echo "Navvi devcontainer ready."
-echo "  VNC:  http://localhost:6080 (password: navvi)"
-echo "  CDP:  port 9222 (launch Chrome with --remote-debugging-port=9222)"
+echo "  VNC:      http://localhost:6080 (password: navvi)"
+echo "  CDP:      port 9222 (via launch-chrome.sh)"
+echo "  PinchTab: port 9867 (via launch-pinchtab.sh)"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Claude Code (brain)
     ↓
 Navvi (persona + browser orchestration)
     ↓
+PinchTab (HTTP API, stealth, accessibility tree)
+    ↓
 Headed Chrome in Codespace (VNC + CDP)
     ↓
 Real websites with isTrusted events
@@ -19,19 +21,59 @@ Real websites with isTrusted events
 ## Quick Start
 
 1. Create a Codespace from this repo
-2. Chrome launches with VNC on port 6080, CDP on port 9222
+2. PinchTab + Chromium install automatically
 3. Define personas in `.navvi/personas/*.yml`
-4. Launch a persona: `./scripts/launch-chrome.sh fry-dev`
+4. Launch:
+
+```bash
+# Via PinchTab (recommended — stealth + accessibility tree)
+./scripts/launch-pinchtab.sh fry-dev --headed
+
+# Or use the CLI wrapper
+./scripts/navvi.sh launch fry-dev --headed
+./scripts/navvi.sh open https://dev.to
+./scripts/navvi.sh snapshot    # 800 tokens, not 10K
+./scripts/navvi.sh screenshot  # full page PNG
+
+# Direct Chrome (fallback — raw CDP, no stealth)
+./scripts/launch-chrome.sh fry-dev
+```
 
 ## Structure
 
 ```
-.devcontainer/       # Codespace config (desktop-lite + Chromium)
+.devcontainer/           # Codespace config (desktop-lite + Chromium + PinchTab)
 .navvi/
-├── personas/        # Persona definitions (YAML, committed)
-└── profiles/        # Browser profiles with cookies (gitignored)
+├── personas/            # Persona definitions (YAML, committed)
+└── profiles/            # Browser profiles with cookies (volume-mounted)
 scripts/
-└── launch-chrome.sh   # Launch headed Chrome for a persona
+├── navvi.sh             # CLI wrapper for PinchTab API
+├── launch-pinchtab.sh   # Launch PinchTab server for a persona
+└── launch-chrome.sh     # Launch raw Chrome with CDP (fallback)
+```
+
+## PinchTab API
+
+PinchTab runs on port 9867 and provides:
+
+```bash
+# Launch a browser instance
+curl -X POST localhost:9867/instances/launch \
+  -d '{"name":"fry-dev","mode":"headed"}'
+
+# Open a URL
+curl -X POST localhost:9867/instances/$ID/tabs/open \
+  -d '{"url":"https://dev.to"}'
+
+# Get accessibility tree (800 tokens vs 10K for screenshots)
+curl localhost:9867/tabs/$TAB/snapshot
+
+# Perform action by element ref
+curl -X POST localhost:9867/tabs/$TAB/action \
+  -d '{"type":"click","ref":"e42"}'
+
+# Screenshot
+curl localhost:9867/tabs/$TAB/screenshot -o page.png
 ```
 
 ## Persona Definition
@@ -55,12 +97,13 @@ browser:
 
 Profiles live in `.navvi/profiles/`, mounted as a Docker volume. They persist across Codespace rebuilds automatically — no backup/restore needed.
 
-## Why Headed Chrome?
+## Why PinchTab + Headed Chrome?
 
-- `isTrusted=true` mouse/keyboard events — passes CAPTCHA detection
-- OAuth popups, cookie banners, multi-step wizards work naturally
-- VNC gives visual debugging — see what the agent sees
-- Persistent profiles keep you logged in across sessions
+- **Stealth** — patches `navigator.webdriver`, spoofs UA, hides automation
+- **Accessibility tree** — 800 tokens to read a page (5-13x cheaper than screenshots)
+- **isTrusted events** — passes CAPTCHA detection via VNC
+- **Persistent sessions** — cookies survive restarts
+- **HTTP API** — framework-agnostic, works with any agent
 
 ## Companion: Flowchad
 

--- a/scripts/launch-pinchtab.sh
+++ b/scripts/launch-pinchtab.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Launch PinchTab server for a given persona.
+# Usage: ./scripts/launch-pinchtab.sh [persona-name] [--headed]
+#
+# PinchTab manages its own Chrome instance with stealth injection.
+# Profile stored in .navvi/profiles/<persona>/
+
+PERSONA="${1:-default}"
+MODE="headless"
+if [ "$2" = "--headed" ]; then
+  MODE="headed"
+fi
+
+PROFILE_DIR="$(pwd)/.navvi/profiles/$PERSONA"
+mkdir -p "$PROFILE_DIR"
+
+echo "Launching PinchTab for persona: $PERSONA ($MODE)"
+echo "  Profile:  $PROFILE_DIR"
+echo "  API:      http://127.0.0.1:9867"
+echo ""
+
+# Start PinchTab server
+exec pinchtab server \
+  --profile "$PROFILE_DIR" \
+  --mode "$MODE"

--- a/scripts/navvi.sh
+++ b/scripts/navvi.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Navvi CLI — thin wrapper around PinchTab HTTP API.
+# Usage:
+#   ./scripts/navvi.sh launch <persona> [--headed]
+#   ./scripts/navvi.sh open <url>
+#   ./scripts/navvi.sh snapshot
+#   ./scripts/navvi.sh action <type> <ref> [value]
+#   ./scripts/navvi.sh screenshot [output-path]
+#   ./scripts/navvi.sh status
+
+API="http://127.0.0.1:9867"
+CMD="${1:?Usage: navvi.sh <command> [args...]}"
+shift
+
+case "$CMD" in
+  launch)
+    PERSONA="${1:-default}"
+    MODE="headless"
+    [ "$2" = "--headed" ] && MODE="headed"
+    PROFILE_DIR="$(pwd)/.navvi/profiles/$PERSONA"
+    mkdir -p "$PROFILE_DIR"
+    RESULT=$(curl -sf -X POST "$API/instances/launch" \
+      -H "Content-Type: application/json" \
+      -d "{\"name\":\"$PERSONA\",\"mode\":\"$MODE\",\"profile\":\"$PROFILE_DIR\"}")
+    echo "$RESULT" | jq -r '.id // "Error: could not launch instance"'
+    ;;
+
+  open)
+    URL="${1:?Usage: navvi.sh open <url>}"
+    INST=$(curl -sf "$API/instances" | jq -r '.[0].id // empty')
+    if [ -z "$INST" ]; then
+      echo "Error: no running instance. Run: navvi.sh launch <persona>"
+      exit 1
+    fi
+    curl -sf -X POST "$API/instances/$INST/tabs/open" \
+      -H "Content-Type: application/json" \
+      -d "{\"url\":\"$URL\"}" | jq .
+    ;;
+
+  snapshot)
+    INST=$(curl -sf "$API/instances" | jq -r '.[0].id // empty')
+    TAB=$(curl -sf "$API/instances/$INST/tabs" | jq -r '.[0].id // empty')
+    if [ -z "$TAB" ]; then
+      echo "Error: no open tab"
+      exit 1
+    fi
+    curl -sf "$API/tabs/$TAB/snapshot" | jq .
+    ;;
+
+  action)
+    TYPE="${1:?Usage: navvi.sh action <type> <ref> [value]}"
+    REF="${2:?Usage: navvi.sh action <type> <ref> [value]}"
+    VALUE="$3"
+    INST=$(curl -sf "$API/instances" | jq -r '.[0].id // empty')
+    TAB=$(curl -sf "$API/instances/$INST/tabs" | jq -r '.[0].id // empty')
+    BODY="{\"type\":\"$TYPE\",\"ref\":\"$REF\""
+    [ -n "$VALUE" ] && BODY="$BODY,\"value\":\"$VALUE\""
+    BODY="$BODY}"
+    curl -sf -X POST "$API/tabs/$TAB/action" \
+      -H "Content-Type: application/json" \
+      -d "$BODY" | jq .
+    ;;
+
+  screenshot)
+    OUTPUT="${1:-/tmp/navvi-screenshot.png}"
+    INST=$(curl -sf "$API/instances" | jq -r '.[0].id // empty')
+    TAB=$(curl -sf "$API/instances/$INST/tabs" | jq -r '.[0].id // empty')
+    curl -sf "$API/tabs/$TAB/screenshot" -o "$OUTPUT"
+    echo "Screenshot saved to $OUTPUT"
+    ;;
+
+  status)
+    curl -sf "$API/instances" | jq .
+    ;;
+
+  *)
+    echo "Unknown command: $CMD"
+    echo "Commands: launch, open, snapshot, action, screenshot, status"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- PinchTab installed in devcontainer via `curl | bash`
- Port 9867 forwarded for PinchTab API
- `launch-pinchtab.sh` — start PinchTab server with persona profile
- `navvi.sh` — CLI wrapper: launch, open, snapshot, action, screenshot, status
- `launch-chrome.sh` kept as raw CDP fallback
- README updated with PinchTab API examples and architecture

Closes #2