### PR TITLE
Credential management — gopass vault integration

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -11,6 +11,30 @@ npm install playwright-core
 # Install PinchTab
 curl -fsSL https://pinchtab.com/install.sh | bash
 
+# Install gopass (credential manager)
+GOPASS_VERSION="1.15.14"
+ARCH=$(dpkg --print-architecture 2>/dev/null || echo "amd64")
+curl -fsSL "https://github.com/gopasspw/gopass/releases/download/v${GOPASS_VERSION}/gopass_${GOPASS_VERSION}_linux_${ARCH}.deb" -o /tmp/gopass.deb
+sudo dpkg -i /tmp/gopass.deb
+rm /tmp/gopass.deb
+
+# Import GPG key from Codespace secret (if available)
+if [ -n "${GPG_PRIVATE_KEY:-}" ]; then
+  echo "$GPG_PRIVATE_KEY" | gpg --batch --import 2>/dev/null
+  GPG_ID=$(gpg --list-secret-keys --keyid-format long 2>/dev/null | grep sec | head -1 | awk '{print $2}' | cut -d/ -f2)
+  if [ -n "$GPG_ID" ]; then
+    # Trust the key ultimately
+    echo "${GPG_ID}:6:" | gpg --import-ownertrust 2>/dev/null
+    # Init gopass if not already
+    if [ ! -d "$HOME/.local/share/gopass/stores/root" ]; then
+      gopass init --path "$HOME/.local/share/gopass/stores/root" "$GPG_ID" 2>/dev/null
+    fi
+    echo "  Gopass:   ready (GPG key imported)"
+  fi
+else
+  echo "  Gopass:   installed (set GPG_PRIVATE_KEY secret to enable)"
+fi
+
 echo ""
 echo "Navvi devcontainer ready."
 echo "  VNC:      http://localhost:6080 (password: navvi)"

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,0 +1,95 @@
+# Credential Management
+
+Navvi uses [gopass](https://github.com/gopasspw/gopass) for credential storage. One GPG key unlocks everything.
+
+## Setup
+
+### 1. Generate a GPG key (once, on your machine)
+
+```bash
+gpg --full-generate-key
+# Choose: RSA, 4096 bits, no expiration
+# Use your persona email (e.g. ayuda.intro@gmail.com)
+```
+
+### 2. Export the private key
+
+```bash
+gpg --armor --export-secret-keys YOUR_KEY_ID > /tmp/gpg-key.asc
+```
+
+### 3. Add as Codespace secret
+
+Go to GitHub → Settings → Codespaces → Secrets → New secret:
+- Name: `GPG_PRIVATE_KEY`
+- Value: contents of `/tmp/gpg-key.asc`
+- Repository access: `Fellowship-dev/navvi`
+
+Delete the exported file: `rm /tmp/gpg-key.asc`
+
+### 4. The devcontainer handles the rest
+
+On Codespace creation, `setup.sh` imports the GPG key and initializes gopass automatically.
+
+## Adding Credentials
+
+```bash
+# Add a service credential
+gopass insert navvi/fry-dev/devto
+```
+
+Use the multiline format (first line = password, then key-value pairs):
+
+```
+hunter2
+username: fry-lobster
+url: https://dev.to/enter
+totp: otpauth://totp/dev.to:fry?secret=JBSWY3DPEHPK3PXP
+```
+
+## Using Credentials
+
+```bash
+# List all credentials for a persona
+./scripts/navvi.sh creds fry-dev
+
+# Show specific service
+./scripts/navvi.sh creds fry-dev devto
+
+# Get credentials for auto-login (writes JSON to temp file)
+./scripts/navvi.sh login fry-dev devto
+```
+
+## TOTP / 2FA
+
+gopass has built-in OTP support. Store the `totp:` URI in the credential entry:
+
+```bash
+# Add TOTP seed
+gopass insert navvi/fry-dev/devto
+# Include: totp: otpauth://totp/...
+
+# Generate current code
+gopass otp navvi/fry-dev/devto
+```
+
+## Gopass Store Structure
+
+```
+~/.local/share/gopass/stores/root/
+└── navvi/
+    ├── fry-dev/
+    │   ├── devto.age
+    │   ├── github.age
+    │   └── lobsters.age
+    └── max-test/
+        └── linkedin.age
+```
+
+## Security Model
+
+- **One secret**: GPG private key stored as Codespace secret
+- **Encrypted at rest**: all credentials encrypted with GPG
+- **No plaintext**: credentials never in YAML, env files, or git
+- **Auto-cleanup**: `navvi login` writes to temp file, auto-deleted after 30s
+- **Syncable**: gopass store can live in a private repo (encrypted, safe to push)

--- a/scripts/navvi.sh
+++ b/scripts/navvi.sh
@@ -10,6 +10,8 @@
 #   ./scripts/navvi.sh snapshot                     Get accessibility tree
 #   ./scripts/navvi.sh action <type> <ref> [value]  Perform action on element
 #   ./scripts/navvi.sh screenshot [output-path]     Capture page screenshot
+#   ./scripts/navvi.sh creds <persona> [service]     Look up credentials via gopass
+#   ./scripts/navvi.sh login <persona> <service>     Auto-login to a service
 
 set -euo pipefail
 
@@ -233,6 +235,81 @@ case "$CMD" in
     echo "Screenshot saved to $OUTPUT"
     ;;
 
+  creds)
+    PERSONA="${1:?Usage: navvi.sh creds <persona> [service]}"
+    SERVICE="${2:-}"
+    GOPASS_PATH="navvi/$PERSONA"
+
+    if ! command -v gopass &>/dev/null; then
+      echo "Error: gopass not installed"
+      exit 1
+    fi
+
+    if [ -n "$SERVICE" ]; then
+      # Show specific service credentials
+      if ! gopass show "$GOPASS_PATH/$SERVICE" 2>/dev/null; then
+        echo "Error: no credentials at $GOPASS_PATH/$SERVICE"
+        echo "Add with: gopass insert $GOPASS_PATH/$SERVICE"
+        exit 1
+      fi
+    else
+      # List available credentials for this persona
+      echo "Credentials for $PERSONA:"
+      gopass ls "$GOPASS_PATH" 2>/dev/null || echo "  (none — add with: gopass insert $GOPASS_PATH/<service>)"
+    fi
+    ;;
+
+  login)
+    PERSONA="${1:?Usage: navvi.sh login <persona> <service>}"
+    SERVICE="${2:?Usage: navvi.sh login <persona> <service>}"
+    GOPASS_PATH="navvi/$PERSONA/$SERVICE"
+
+    # Check instance is running
+    ID=$(get_instance "$PERSONA")
+    if [ -z "$ID" ]; then
+      echo "Error: persona $PERSONA is not running. Run: navvi.sh up $PERSONA"
+      exit 1
+    fi
+
+    # Get credentials from gopass
+    PASS_OUTPUT=$(gopass show "$GOPASS_PATH" 2>/dev/null)
+    if [ -z "$PASS_OUTPUT" ]; then
+      echo "Error: no credentials at $GOPASS_PATH"
+      exit 1
+    fi
+
+    PASSWORD=$(echo "$PASS_OUTPUT" | head -1)
+    USERNAME=$(echo "$PASS_OUTPUT" | grep "^username:" | sed 's/^username:[[:space:]]*//')
+    URL=$(echo "$PASS_OUTPUT" | grep "^url:" | sed 's/^url:[[:space:]]*//')
+    TOTP_URI=$(echo "$PASS_OUTPUT" | grep "^totp:" | sed 's/^totp:[[:space:]]*//')
+
+    echo "Login: $PERSONA → $SERVICE"
+    [ -n "$URL" ] && echo "  URL:      $URL"
+    [ -n "$USERNAME" ] && echo "  Username: $USERNAME"
+    echo "  Password: ****"
+    [ -n "$TOTP_URI" ] && echo "  TOTP:     available"
+
+    # Output credentials as JSON for agent consumption (not to terminal)
+    # Agent reads this to fill forms via PinchTab actions
+    CREDS_JSON="{\"service\":\"$SERVICE\""
+    [ -n "$USERNAME" ] && CREDS_JSON="$CREDS_JSON,\"username\":\"$USERNAME\""
+    CREDS_JSON="$CREDS_JSON,\"password\":\"$PASSWORD\""
+    [ -n "$URL" ] && CREDS_JSON="$CREDS_JSON,\"url\":\"$URL\""
+    if [ -n "$TOTP_URI" ]; then
+      TOTP_CODE=$(gopass otp "$GOPASS_PATH" 2>/dev/null || echo "")
+      [ -n "$TOTP_CODE" ] && CREDS_JSON="$CREDS_JSON,\"totp\":\"$TOTP_CODE\""
+    fi
+    CREDS_JSON="$CREDS_JSON}"
+
+    # Write to temp file for agent to read, not stdout
+    CREDS_FILE="/tmp/.navvi-creds-$$"
+    echo "$CREDS_JSON" > "$CREDS_FILE"
+    echo "  Credentials written to $CREDS_FILE (auto-deleted in 30s)"
+
+    # Auto-delete after 30s
+    (sleep 30 && rm -f "$CREDS_FILE") &
+    ;;
+
   *)
     echo "Unknown command: $CMD"
     echo ""
@@ -248,6 +325,10 @@ case "$CMD" in
     echo "  snapshot                     Get accessibility tree"
     echo "  action <type> <ref> [value]  Click, fill, etc."
     echo "  screenshot [path]            Capture page"
+    echo ""
+    echo "Credentials:"
+    echo "  creds <persona> [service]    Look up gopass credentials"
+    echo "  login <persona> <service>    Get credentials for auto-login"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary
- gopass installed in devcontainer (deb package)
- GPG key auto-imported from `GPG_PRIVATE_KEY` Codespace secret on startup
- `navvi.sh creds <persona> [service]` — list/show credentials from gopass store
- `navvi.sh login <persona> <service>` — extract credentials + TOTP as JSON to temp file (auto-deleted 30s)
- `docs/credentials.md` — full setup guide: GPG key generation, Codespace secret, adding creds, TOTP, security model

Closes #6