### PR TITLE
Add Codespace lifecycle tools to MCP server

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,6 @@
 # Navvi MCP Server
 
-MCP server that wraps PinchTab's HTTP API as Claude Code tools.
+MCP server for Codespace lifecycle management and PinchTab browser control as Claude Code tools.
 
 ## Setup
 
@@ -19,11 +19,23 @@ Copy `mcp.json` to your project's `.mcp.json`, or add the navvi entry to an exis
 
 ## Available Tools
 
+### Codespace Lifecycle
+
+| Tool | Description |
+|------|-------------|
+| `navvi_codespaces_list` | List available Codespaces (running and stopped) |
+| `navvi_codespace_start` | Create new or resume stopped Codespace |
+| `navvi_codespace_stop` | Stop a running Codespace |
+| `navvi_codespace_connect` | Port-forward PinchTab from Codespace to localhost |
+| `navvi_codespace_disconnect` | Stop port forwarding |
+
+### Browser Control
+
 | Tool | Description |
 |------|-------------|
 | `navvi_up` | Launch a browser instance for a persona |
 | `navvi_down` | Stop instance(s) |
-| `navvi_status` | List running instances |
+| `navvi_status` | List running instances and connection status |
 | `navvi_open` | Navigate to a URL |
 | `navvi_snapshot` | Get accessibility tree (~800 tokens) |
 | `navvi_click` | Click element by ref |
@@ -33,21 +45,28 @@ Copy `mcp.json` to your project's `.mcp.json`, or add the navvi entry to an exis
 ## How It Works
 
 ```
-Claude Code → MCP stdio → server.mjs → HTTP → PinchTab → Chrome
+Claude Code → MCP stdio → server.mjs → gh cs → Codespace → PinchTab → Chrome
 ```
 
-Zero dependencies — uses Node built-in `http` module only. PinchTab must be running on port 9867.
+Typical workflow:
+1. `navvi_codespaces_list` — see what's available
+2. `navvi_codespace_start` — spin up or resume a Codespace
+3. `navvi_codespace_connect` — port-forward PinchTab to localhost
+4. `navvi_up` / `navvi_open` / `navvi_snapshot` — browse
+5. `navvi_codespace_stop` — done, stop billing
+
+Zero dependencies — uses Node built-in `http` module and `gh` CLI only.
 
 ## Example
-
-Once configured, Claude Code sees Navvi tools natively:
 
 ```
 User: "Go to dev.to and show me the trending articles"
 
 Claude Code:
-  → navvi_up(persona: "fry-dev")
+  → navvi_codespaces_list()        # check what's available
+  → navvi_codespace_start()        # spin up compute
+  → navvi_codespace_connect()      # tunnel PinchTab to localhost
+  → navvi_up(persona: "fry-dev")   # launch browser
   → navvi_open(url: "https://dev.to")
-  → navvi_snapshot()
-  → [reads accessibility tree, finds article links]
+  → navvi_snapshot()               # read the page
 ```

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 /**
- * Navvi MCP Server — wraps PinchTab HTTP API as MCP tools.
+ * Navvi MCP Server — Codespace lifecycle + PinchTab browser control.
  *
- * Exposes browser control tools to Claude Code:
+ * Codespace tools (work locally, manage remote compute):
+ *   navvi_codespaces_list, navvi_codespace_start, navvi_codespace_stop,
+ *   navvi_codespace_connect, navvi_codespace_disconnect
+ *
+ * Browser tools (work once connected to a Codespace):
  *   navvi_up, navvi_down, navvi_status,
  *   navvi_open, navvi_snapshot, navvi_click, navvi_fill, navvi_screenshot
  *
@@ -10,20 +14,40 @@
  */
 
 const http = require('http');
+const { execSync, spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 
-const PINCHTAB_API = process.env.PINCHTAB_API || 'http://127.0.0.1:9867';
+const REPO = process.env.NAVVI_REPO || 'Fellowship-dev/navvi';
+const MACHINE_TYPE = process.env.NAVVI_MACHINE || 'basicLinux32gb';
+const PINCHTAB_PORT = 9867;
+const PIDFILE = path.join(os.tmpdir(), '.navvi-port-forward.pid');
+
+let pinchtabApi = process.env.PINCHTAB_API || `http://127.0.0.1:${PINCHTAB_PORT}`;
+
+// --- Shell helper ---
+
+function sh(cmd) {
+  try {
+    return execSync(cmd, { encoding: 'utf8', timeout: 60000 }).trim();
+  } catch (e) {
+    return e.stderr ? e.stderr.trim() : e.message;
+  }
+}
 
 // --- HTTP helper (no deps) ---
 
-function apiCall(method, path, body) {
+function apiCall(method, apiPath, body) {
   return new Promise((resolve, reject) => {
-    const url = new URL(path, PINCHTAB_API);
+    const url = new URL(apiPath, pinchtabApi);
     const options = {
       hostname: url.hostname,
       port: url.port,
       path: url.pathname,
       method,
       headers: { 'Content-Type': 'application/json' },
+      timeout: 10000,
     };
     const req = http.request(options, (res) => {
       let data = '';
@@ -37,9 +61,19 @@ function apiCall(method, path, body) {
       });
     });
     req.on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(new Error('Request timeout')); });
     if (body) req.write(JSON.stringify(body));
     req.end();
   });
+}
+
+function isPinchtabReachable() {
+  try {
+    const result = sh(`curl -sf -o /dev/null -w '%{http_code}' ${pinchtabApi}/instances 2>/dev/null`);
+    return result === '200';
+  } catch {
+    return false;
+  }
 }
 
 async function getFirstInstance() {
@@ -57,9 +91,51 @@ async function getFirstTab(instanceId) {
 // --- MCP Tool Definitions ---
 
 const TOOLS = [
+  // Codespace lifecycle
+  {
+    name: 'navvi_codespaces_list',
+    description: 'List available Navvi Codespaces (running and stopped).',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'navvi_codespace_start',
+    description: 'Start a new Navvi Codespace or resume a stopped one. Returns codespace name.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Codespace name (optional — creates new if omitted, resumes if provided)' },
+      },
+    },
+  },
+  {
+    name: 'navvi_codespace_stop',
+    description: 'Stop a running Navvi Codespace.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Codespace name (optional — stops first running one if omitted)' },
+      },
+    },
+  },
+  {
+    name: 'navvi_codespace_connect',
+    description: 'Forward PinchTab port from a running Codespace to localhost. Must be called after start and before browser tools.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Codespace name (optional — connects to first running one if omitted)' },
+      },
+    },
+  },
+  {
+    name: 'navvi_codespace_disconnect',
+    description: 'Stop port forwarding to the Codespace.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  // Browser control (PinchTab)
   {
     name: 'navvi_up',
-    description: 'Launch a browser instance for a persona. Returns instance ID.',
+    description: 'Launch a browser instance for a persona inside the connected Codespace. Returns instance ID.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -81,7 +157,7 @@ const TOOLS = [
   },
   {
     name: 'navvi_status',
-    description: 'List all running browser instances.',
+    description: 'List running browser instances and connection status.',
     inputSchema: { type: 'object', properties: {} },
   },
   {
@@ -134,6 +210,89 @@ const TOOLS = [
 
 async function handleTool(name, args) {
   switch (name) {
+    // --- Codespace lifecycle ---
+
+    case 'navvi_codespaces_list': {
+      const output = sh(`gh cs list --repo ${REPO} --json name,state,createdAt,machine -q '.[] | "\\(.name)  \\(.state)  \\(.machine.displayName // "unknown")  \\(.createdAt)"'`);
+      if (!output) return `No Codespaces found for ${REPO}.\nCreate one with navvi_codespace_start.`;
+      return `Navvi Codespaces:\n${output}`;
+    }
+
+    case 'navvi_codespace_start': {
+      if (args.name) {
+        // Resume existing
+        sh(`gh cs start -c ${args.name}`);
+        return `Started Codespace: ${args.name}\nConnect with navvi_codespace_connect.`;
+      }
+      // Create new
+      const output = sh(`gh cs create --repo ${REPO} --machine ${MACHINE_TYPE} --json name -q '.name'`);
+      return `Created Codespace: ${output}\nConnect with navvi_codespace_connect.`;
+    }
+
+    case 'navvi_codespace_stop': {
+      let csName = args.name;
+      if (!csName) {
+        csName = sh(`gh cs list --repo ${REPO} --json name,state -q '.[] | select(.state=="Available") | .name' | head -1`);
+      }
+      if (!csName) return 'No running Codespace found.';
+      sh(`gh cs stop -c ${csName}`);
+      // Also disconnect if forwarding
+      if (fs.existsSync(PIDFILE)) {
+        try {
+          const pid = fs.readFileSync(PIDFILE, 'utf8').trim();
+          process.kill(parseInt(pid));
+        } catch {}
+        fs.unlinkSync(PIDFILE);
+      }
+      return `Stopped Codespace: ${csName}`;
+    }
+
+    case 'navvi_codespace_connect': {
+      // Kill existing forward if any
+      if (fs.existsSync(PIDFILE)) {
+        try {
+          const pid = fs.readFileSync(PIDFILE, 'utf8').trim();
+          process.kill(parseInt(pid));
+        } catch {}
+        fs.unlinkSync(PIDFILE);
+      }
+
+      let csName = args.name;
+      if (!csName) {
+        csName = sh(`gh cs list --repo ${REPO} --json name,state -q '.[] | select(.state=="Available") | .name' | head -1`);
+      }
+      if (!csName) return 'No running Codespace found. Start one with navvi_codespace_start.';
+
+      // Start port forward in background
+      const child = spawn('gh', ['cs', 'ports', 'forward', `${PINCHTAB_PORT}:${PINCHTAB_PORT}`, '-c', csName], {
+        detached: true,
+        stdio: 'ignore',
+      });
+      child.unref();
+      fs.writeFileSync(PIDFILE, String(child.pid));
+
+      // Wait a moment for the tunnel to establish
+      await new Promise((r) => setTimeout(r, 3000));
+
+      const reachable = isPinchtabReachable();
+      return `Connected to ${csName}\n  Port forward: localhost:${PINCHTAB_PORT} → Codespace\n  PinchTab: ${reachable ? 'reachable' : 'not yet reachable (PinchTab may need to be started inside the Codespace)'}`;
+    }
+
+    case 'navvi_codespace_disconnect': {
+      if (!fs.existsSync(PIDFILE)) return 'No active port forward.';
+      try {
+        const pid = fs.readFileSync(PIDFILE, 'utf8').trim();
+        process.kill(parseInt(pid));
+        fs.unlinkSync(PIDFILE);
+        return 'Disconnected. Port forward stopped.';
+      } catch (e) {
+        fs.unlinkSync(PIDFILE);
+        return `Disconnected (process may have already exited).`;
+      }
+    }
+
+    // --- Browser control (PinchTab) ---
+
     case 'navvi_up': {
       const { persona, mode = 'headed' } = args;
       const result = await apiCall('POST', '/instances/launch', {
@@ -157,9 +316,25 @@ async function handleTool(name, args) {
     }
 
     case 'navvi_status': {
-      const instances = await apiCall('GET', '/instances');
-      if (!Array.isArray(instances) || instances.length === 0) return 'No running instances.';
-      return instances.map((i) => `${i.name} — ${i.id} (${i.mode || 'unknown'})`).join('\n');
+      const connected = isPinchtabReachable();
+      let status = `PinchTab: ${connected ? 'connected' : 'not connected'}`;
+      if (fs.existsSync(PIDFILE)) {
+        status += ` (port forward PID: ${fs.readFileSync(PIDFILE, 'utf8').trim()})`;
+      }
+      if (connected) {
+        try {
+          const instances = await apiCall('GET', '/instances');
+          if (Array.isArray(instances) && instances.length > 0) {
+            status += '\n\nRunning instances:\n' +
+              instances.map((i) => `  ${i.name} — ${i.id} (${i.mode || 'unknown'})`).join('\n');
+          } else {
+            status += '\n\nNo browser instances running. Launch one with navvi_up.';
+          }
+        } catch {
+          status += '\n\nCould not list instances.';
+        }
+      }
+      return status;
     }
 
     case 'navvi_open': {
@@ -183,10 +358,7 @@ async function handleTool(name, args) {
       if (!instId) return 'Error: no running instance.';
       const tabId = await getFirstTab(instId);
       if (!tabId) return 'Error: no open tab.';
-      const result = await apiCall('POST', `/tabs/${tabId}/action`, {
-        type: 'click',
-        ref: args.ref,
-      });
+      await apiCall('POST', `/tabs/${tabId}/action`, { type: 'click', ref: args.ref });
       return `Clicked ${args.ref}`;
     }
 
@@ -195,11 +367,7 @@ async function handleTool(name, args) {
       if (!instId) return 'Error: no running instance.';
       const tabId = await getFirstTab(instId);
       if (!tabId) return 'Error: no open tab.';
-      const result = await apiCall('POST', `/tabs/${tabId}/action`, {
-        type: 'fill',
-        ref: args.ref,
-        value: args.value,
-      });
+      await apiCall('POST', `/tabs/${tabId}/action`, { type: 'fill', ref: args.ref, value: args.value });
       return `Filled ${args.ref} with "${args.value}"`;
     }
 
@@ -208,9 +376,8 @@ async function handleTool(name, args) {
       if (!instId) return 'Error: no running instance.';
       const tabId = await getFirstTab(instId);
       if (!tabId) return 'Error: no open tab.';
-      // Get raw screenshot bytes
       return new Promise((resolve, reject) => {
-        const url = new URL(`/tabs/${tabId}/screenshot`, PINCHTAB_API);
+        const url = new URL(`/tabs/${tabId}/screenshot`, pinchtabApi);
         http.get(url, (res) => {
           const chunks = [];
           res.on('data', (chunk) => chunks.push(chunk));
@@ -229,22 +396,18 @@ async function handleTool(name, args) {
 
 // --- MCP stdio protocol ---
 
-let buffer = '';
+let msgBuffer = '';
 
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', (chunk) => {
-  buffer += chunk;
-  // Process complete JSON-RPC messages (newline-delimited)
-  const lines = buffer.split('\n');
-  buffer = lines.pop(); // keep incomplete line in buffer
+  msgBuffer += chunk;
+  const lines = msgBuffer.split('\n');
+  msgBuffer = lines.pop();
   for (const line of lines) {
     if (!line.trim()) continue;
     try {
-      const msg = JSON.parse(line);
-      handleMessage(msg);
-    } catch (e) {
-      // Skip malformed lines
-    }
+      handleMessage(JSON.parse(line));
+    } catch {}
   }
 });
 
@@ -263,13 +426,12 @@ async function handleMessage(msg) {
         result: {
           protocolVersion: '2024-11-05',
           capabilities: { tools: {} },
-          serverInfo: { name: 'navvi', version: '0.1.0' },
+          serverInfo: { name: 'navvi', version: '0.2.0' },
         },
       });
       break;
 
     case 'notifications/initialized':
-      // Client acknowledges init — no response needed
       break;
 
     case 'tools/list':
@@ -277,18 +439,14 @@ async function handleMessage(msg) {
       break;
 
     case 'tools/call': {
-      const { name, arguments: args } = params;
+      const { name, arguments: callArgs } = params;
       try {
-        const result = await handleTool(name, args || {});
+        const result = await handleTool(name, callArgs || {});
         if (typeof result === 'object' && result.type === 'image') {
           send({
             jsonrpc: '2.0',
             id,
-            result: {
-              content: [
-                { type: 'image', data: result.data, mimeType: result.mimeType },
-              ],
-            },
+            result: { content: [{ type: 'image', data: result.data, mimeType: result.mimeType }] },
           });
         } else {
           send({
@@ -314,4 +472,14 @@ async function handleMessage(msg) {
   }
 }
 
-process.stderr.write('Navvi MCP server started\n');
+// Cleanup port forward on exit
+process.on('exit', () => {
+  if (fs.existsSync(PIDFILE)) {
+    try {
+      process.kill(parseInt(fs.readFileSync(PIDFILE, 'utf8').trim()));
+      fs.unlinkSync(PIDFILE);
+    } catch {}
+  }
+});
+
+process.stderr.write('Navvi MCP server started (v0.2.0)\n');


### PR DESCRIPTION
## Summary
- Adds 5 Codespace lifecycle tools: `list`, `start`, `stop`, `connect`, `disconnect`
- Port forwarding via `gh cs ports forward` with PID tracking and cleanup
- Updated README with full workflow docs and tool reference
- Server bumped to v0.2.0

Closes #8

## Test plan
- [ ] `navvi_codespaces_list` returns available Codespaces
- [ ] `navvi_codespace_start` creates/resumes a Codespace
- [ ] `navvi_codespace_connect` establishes port forward and PinchTab is reachable
- [ ] Browser tools work through the tunnel
- [ ] `navvi_codespace_disconnect` + `stop` clean up properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)