### PR TITLE
Persist gopass/GPG state in Docker volumes

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -69,8 +69,10 @@ RUN useradd -m -s /bin/bash user
 USER user
 WORKDIR /home/user
 
-# Browser profile directory (mount a named volume here for persistence)
-RUN mkdir -p /home/user/.mozilla
+# Persistent directories (mount named volumes here for persistence)
+# Pre-creating with correct ownership ensures Docker copies perms to fresh volumes
+RUN mkdir -p /home/user/.mozilla /home/user/.local/share/gopass \
+    && mkdir -m 700 -p /home/user/.gnupg
 
 EXPOSE 8024 6080
 

--- a/container/start.sh
+++ b/container/start.sh
@@ -61,7 +61,7 @@ if [ -n "${GPG_PRIVATE_KEY:-}" ]; then
   fi
   unset GPG_PRIVATE_KEY
 elif [ -n "$(gpg --list-secret-keys 2>/dev/null)" ]; then
-  # Existing key from persistent volume (Codespaces)
+  # Existing key from persistent volume (Docker volumes or Codespaces)
   GPG_ID=$(gpg --list-secret-keys --keyid-format long 2>/dev/null | grep sec | head -1 | awk '{print $2}' | cut -d/ -f2)
   if [ -n "$GPG_ID" ] && [ ! -d "$HOME/.local/share/gopass/stores/root" ]; then
     gopass init --path "$HOME/.local/share/gopass/stores/root" "$GPG_ID" 2>/dev/null

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -52,9 +52,9 @@ Use the multiline format (first line = password, then key-value pairs):
 
 ```
 hunter2
-username: fry-lobster
+username: myuser
 url: https://dev.to/enter
-totp: otpauth://totp/dev.to:fry?secret=JBSWY3DPEHPK3PXP
+totp: otpauth://totp/dev.to:myuser?secret=JBSWY3DPEHPK3PXP
 ```
 
 ## Using Credentials

--- a/src/navvi/__init__.py
+++ b/src/navvi/__init__.py
@@ -507,7 +507,7 @@ async def navvi_persona(
             if name == "default":
                 return "Error: cannot delete the default persona."
             if delete_persona(name):
-                return f"Persona '{name}' deleted. Docker volume navvi-profile-{name} is preserved (remove manually with: docker volume rm navvi-profile-{name})."
+                return f"Persona '{name}' deleted. Docker volumes preserved (remove manually with: docker volume rm navvi-profile-{name} navvi-gpg-{name} navvi-gopass-{name})."
             return f"Persona '{name}' not found."
 
         else:
@@ -626,8 +626,10 @@ async def navvi_start(
             locale = config.get("locale", "en-US")
             timezone = config.get("timezone", "UTC")
 
-        # Docker volume for persistent Firefox profile
+        # Docker volumes for persistent state
         volume_name = f"navvi-profile-{persona}"
+        gpg_volume = f"navvi-gpg-{persona}"
+        gopass_volume = f"navvi-gopass-{persona}"
 
         # Find ports
         api_port = NAVVI_PORT
@@ -646,6 +648,8 @@ async def navvi_start(
             "-p", f"{api_port}:8024",
             "-p", f"{vnc_port}:6080",
             "-v", f"{volume_name}:/home/user/.mozilla",
+            "-v", f"{gpg_volume}:/home/user/.gnupg",
+            "-v", f"{gopass_volume}:/home/user/.local/share/gopass",
             "-e", f"LOCALE={locale}",
             "-e", f"TIMEZONE={timezone}",
             DOCKER_IMAGE,


### PR DESCRIPTION
## Summary
- Adds `navvi-gpg-<persona>` and `navvi-gopass-<persona>` Docker volumes alongside existing Firefox profile volume
- Pre-creates `~/.gnupg` (mode 700) and `~/.local/share/gopass` in Dockerfile with correct `user` ownership
- Updates `navvi_start` to mount all 3 volumes, and persona delete message to list all volumes
- Removes `fry-lobster` username from docs example

## Test plan
- [x] Reproduced bug: gopass creds lost on container restart (before fix)
- [x] Applied fix: creds survive stop → rm → run cycle
- [x] Verified `~/.gnupg` ownership is `user:user` with mode 700 (no GPG warnings)
- [x] Clean gopass init + store + restart + retrieve cycle passes

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)