### PR TITLE
Fix atomic tools visibility + browse reliability

### DIFF
--- a/container/start.sh
+++ b/container/start.sh
@@ -143,6 +143,18 @@ if ! kill -0 "$FIREFOX_PID" 2>/dev/null; then
   exit 1
 fi
 
+# Maximize browser window to fill the virtual display
+echo "[navvi] Maximizing browser window..."
+for i in 1 2 3; do
+  WID=$(xdotool search --onlyvisible --class "firefox\|Navigator\|camoufox" 2>/dev/null | head -1)
+  if [ -n "$WID" ]; then
+    xdotool windowactivate "$WID" windowsize "$WID" 1920 1080 windowmove "$WID" 0 0 2>/dev/null
+    echo "[navvi] Window $WID maximized"
+    break
+  fi
+  sleep 1
+done
+
 echo "[navvi] Starting x11vnc..."
 x11vnc -display "$DISPLAY" -forever -shared -nopw -rfbport 5900 -bg -q 2>/dev/null
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "navvi"
-version = "3.11.0"
+version = "3.12.0"
 description = "Give your AI agent a real browser identity — MCP server with persistent personas, anti-detection browser, and credential vault."
 readme = "README.md"
 license = "MIT"

--- a/skills/navvi-signup/SKILL.md
+++ b/skills/navvi-signup/SKILL.md
@@ -49,6 +49,19 @@ If autofill fails (non-standard form, multiple forms with same field names):
 3. For password: use `navvi_creds(action="autofill")` with explicit selectors, or tab to the password field and use autofill
 4. NEVER type passwords manually
 
+### Custom Dropdowns (Fluent UI, React Select, etc.)
+
+Do NOT use `navvi_browse` for custom dropdowns — it gets stuck in scroll loops.
+Use atomic tools directly:
+
+1. Find the dropdown trigger: `navvi_find("[role=combobox]")` or `navvi_find("select")`
+2. Click to open it: `navvi_click(x, y)`
+3. Find all options: `navvi_find("[role=option]", all=true)`
+4. Find and click the desired option by text match
+5. If the option list is long, use `navvi_find("[role=option]:text('Chile')")` or scroll within the dropdown
+
+For **native `<select>` elements**: type the first letter(s) of the option after clicking to jump to it.
+
 ### Step 5: Screenshot and verify form is filled
 ```
 mcp__navvi__navvi_screenshot()
@@ -69,7 +82,8 @@ mcp__navvi__navvi_click(x=..., y=...)
   mcp__navvi__navvi_click(x=..., y=...)
   ```
   If an image challenge appears or 3 clicks fail → `navvi_vnc()` for human help
-- **Other CAPTCHAs** (Arkose/FunCaptcha, hCaptcha): `navvi_vnc()` immediately
+- **Arkose Labs / Human Security (press-and-hold)**: use `navvi_hold(x, y, duration_ms=5000)` on the verify button. These CAPTCHAs typically appear AFTER filling all form fields, not on intermediate Next buttons.
+- **Other CAPTCHAs** (hCaptcha, image puzzles): `navvi_vnc()` immediately
 
 ### Step 8: Verify account creation
 Screenshot and confirm success. Look for welcome messages, dashboard, confirmation page.

--- a/skills/navvi-signup/playbooks/outlook.md
+++ b/skills/navvi-signup/playbooks/outlook.md
@@ -1,0 +1,90 @@
+# Outlook / Microsoft Account Signup Playbook
+
+Tested flow as of March 2026. Microsoft changes their UI frequently — verify each step with screenshots.
+
+## URL
+
+`https://signup.live.com`
+
+## Flow (7 steps)
+
+### Step 1: Email
+
+Page title: "Create your Microsoft account"
+
+- The email field and a `@outlook.com` domain dropdown are shown
+- Type the username only (e.g. `april.voss.research`) — do NOT include `@outlook.com`
+- Verify the domain dropdown shows `@outlook.com` (it's the default): `navvi_find("[role=combobox][name*=domain]")`
+- Click Next: `navvi_find("button[type=submit]")` → `navvi_click(x, y)`
+- **No CAPTCHA on this step** — if Next doesn't advance, check for validation errors (email taken, invalid chars)
+
+### Step 2: Password
+
+Page title: "Create your password"
+
+- Use `navvi_creds(action="autofill", entry="...", x=PASSWORD_X, y=PASSWORD_Y)` to fill password securely
+- The page has only a password field (no username field) — autofill handles this
+- Click Next: `navvi_find("button[type=submit]")` → `navvi_click(x, y)`
+
+### Step 3: Details (country + birthdate)
+
+Page title: "Add some details"
+
+- **Country**: Chile is the default if persona locale is `es-CL`. Check with `navvi_find("[id*=Country], [role=combobox][aria-label*=country]")`. If already correct, do NOT touch the dropdown.
+- **Birthdate**: 3 fields
+  - Month: Fluent UI combobox → `navvi_find("#BirthMonthDropdown")` → click → `navvi_find("[role=option]", all=true)` → click desired month
+  - Day: Same pattern → `navvi_find("#BirthDayDropdown")` → click → find option → click
+  - Year: Number input → `navvi_find("input[name=BirthYear]")` → `navvi_fill(x, y, "1991")`
+- Use plausible fake data (NOT real personal info)
+- Click Next
+
+### Step 4: Name
+
+Page title: "Add your name"
+
+- Two text inputs: `navvi_find("#firstNameInput")` and `navvi_find("#lastNameInput")`
+- **IMPORTANT**: Click each field explicitly before typing. The `navvi_fill` command auto-clicks at (x,y) but the fields are close together — verify with `navvi_find` after filling to confirm values are in the right fields.
+- Click Next
+
+### Step 5: CAPTCHA (Arkose Labs / Human Security)
+
+This is where the CAPTCHA appears — a press-and-hold verification button.
+
+- Find the verify button (usually the submit/Next button on this page)
+- Use `navvi_hold(x, y, duration_ms=5000)` — press and hold for 5 seconds
+- If it fails or shows an image puzzle → `navvi_vnc()` for human intervention
+
+### Step 6: Privacy notice
+
+- Click "OK" or "Accept" button
+- `navvi_find("button[id*=accept], button[type=submit]")` → click
+
+### Step 7: "Stay signed in?"
+
+- Click "Yes" to stay signed in
+- `navvi_find("button[id*=accept], button[type=submit]")` → click
+- Final page: `account.microsoft.com` — signed in
+
+## Selectors Reference
+
+| Element | Selector |
+|---|---|
+| Email input | `input[type=email]` |
+| Domain dropdown | `[role=combobox][id*=domain]` |
+| Password input | `input[type=password]` |
+| Country dropdown | `[role=combobox][id*=Country]` |
+| Month dropdown | `#BirthMonthDropdown` |
+| Day dropdown | `#BirthDayDropdown` |
+| Year input | `input[name=BirthYear]` |
+| First name | `#firstNameInput` |
+| Last name | `#lastNameInput` |
+| Next/Submit button | `button[type=submit]` |
+| Dropdown options | `[role=option]` |
+
+## Common Pitfalls
+
+1. **navvi_fill types into wrong field** — always `navvi_find` first, then use the returned (x,y)
+2. **Country dropdown scroll loop** — do NOT use `navvi_browse` for this. Chile is usually already selected.
+3. **CAPTCHA is at step 5, NOT step 1** — the email Next button has no CAPTCHA
+4. **Year is a number input, not a dropdown** — use `navvi_fill`, not dropdown click pattern
+5. **Persona viewport** — ensure browser window is maximized so all form elements are visible

--- a/src/navvi/__init__.py
+++ b/src/navvi/__init__.py
@@ -1743,7 +1743,7 @@ async def _execute_action(action: dict, api_base: str, dom_elements: list):
 
     elif atype == "fill":
         selector = action.get("selector_hint", "")
-        value = action.get("value", "")
+        value = action.get("text", "") or action.get("value", "")
         if selector and value:
             try:
                 resp = await api_call("POST", "/find", {"selector": selector}, api_base)
@@ -1757,14 +1757,16 @@ async def _execute_action(action: dict, api_base: str, dom_elements: list):
                 pass
 
     elif atype == "press":
-        key = action.get("value", "Return")
+        key = action.get("key") or action.get("value") or "Return"
+        if not isinstance(key, str) or not key:
+            key = "Return"
         await api_call("POST", "/key", {"key": key}, api_base)
 
     elif atype == "scroll":
         await api_call("POST", "/scroll", {"direction": "down", "amount": 3}, api_base)
 
     elif atype == "navigate":
-        nav_url = action.get("value", "")
+        nav_url = action.get("url") or action.get("value", "")
         if nav_url:
             await api_call("POST", "/navigate", {"url": nav_url}, api_base)
 
@@ -1845,6 +1847,13 @@ async def navvi_browse(
 
     steps_log = []
 
+    # Fetch viewport info once (doesn't change between steps)
+    viewport_info = None
+    try:
+        viewport_info = await api_call("GET", "/viewport", api_base=api_base)
+    except Exception:
+        pass
+
     for step in range(max_steps):
         # 1. Get current state
         try:
@@ -1873,8 +1882,8 @@ async def navvi_browse(
         except Exception:
             dom_elements = []
 
-        # 4. Analyze
-        analysis = await analyze(screenshot_b64, dom_elements, instruction, current_url, current_title)
+        # 4. Analyze (pass recent steps so Haiku doesn't repeat failed actions)
+        analysis = await analyze(screenshot_b64, dom_elements, instruction, current_url, current_title, steps_log, viewport_info)
 
         tier = analysis.get("tier_used", "unknown")
         confidence = analysis.get("confidence", 0)
@@ -1896,6 +1905,22 @@ async def navvi_browse(
             shot_path = _save_screenshot(screenshot_b64) if screenshot_b64 else "(no screenshot)"
             summary = _format_steps_log(steps_log)
             return "Completed in {} steps.\n\n{}\n\nFinal screenshot: {}".format(step + 1, summary, shot_path)
+
+        # 5b. Check if stuck (3 identical consecutive actions)
+        if len(steps_log) >= 3:
+            last3 = steps_log[-3:]
+            if (
+                all(s["action_taken"] == last3[0]["action_taken"] for s in last3)
+                and all(s["page_type"] == last3[0]["page_type"] for s in last3)
+            ):
+                shot_path = _save_screenshot(screenshot_b64) if screenshot_b64 else "(no screenshot)"
+                summary = _format_steps_log(steps_log)
+                return (
+                    "Stuck: repeated '{}' action 3 times on '{}' page with no progress.\n\n"
+                    "Steps so far:\n{}\n\n"
+                    "Screenshot: {}\n\n"
+                    "Use atomic tools (navvi_find, navvi_click) to interact directly."
+                ).format(last3[0]["action_taken"], last3[0]["page_type"], summary, shot_path)
 
         # 6. Check if stuck (low confidence + heuristics tier = ask for guidance)
         if confidence < 0.5 and tier == "heuristics":

--- a/src/navvi/__init__.py
+++ b/src/navvi/__init__.py
@@ -85,7 +85,7 @@ active_persona: Optional[str] = None
 
 mcp = FastMCP(
     "navvi",
-    version="3.11.0",
+    version="3.12.0",
 )
 
 # Ensure default persona exists on startup

--- a/src/navvi/__init__.py
+++ b/src/navvi/__init__.py
@@ -91,10 +91,10 @@ mcp = FastMCP(
 # Ensure default persona exists on startup
 ensure_default()
 
-# Progressive disclosure: hide atomic tools by default.
-# Journey tools (navvi_browse, navvi_login) handle most interactions.
-# Atomic tools (navvi_click, navvi_find, etc.) are available on demand.
-mcp.disable(tags={"atomic", "recording"})
+# Recording tools hidden by default (rarely needed).
+# Atomic tools are always visible — Claude Code doesn't support dynamic
+# tool registration mid-session, so hide/reveal via navvi_atomic is broken.
+mcp.disable(tags={"recording"})
 
 
 # --- MCP Resources ---
@@ -1786,27 +1786,13 @@ async def _execute_action(action: dict, api_base: str, dom_elements: list):
 
 @mcp.tool()
 async def navvi_atomic(enable: bool = True, ctx: Context = None) -> str:
-    """Enable or disable atomic browser tools (navvi_click, navvi_find, navvi_fill, etc.).
+    """Quick reference for atomic browser tools (navvi_click, navvi_find, navvi_fill, etc.).
 
-    Atomic tools are hidden by default — use navvi_browse for most tasks.
-    Enable atomic tools only when navvi_browse asks for guidance or you need fine-grained control.
+    Atomic tools are always available. Call this for a summary of tools and workflow.
 
-    Example: navvi_atomic(enable=true) → reveals 12 low-level tools
+    Example: navvi_atomic() → lists all atomic tools with parameters
     """
-    if ctx:
-        # Session-level: sends notifications/tools/list_changed → CC re-fetches tool list
-        if enable:
-            await ctx.enable_components(tags={"atomic"})
-        else:
-            await ctx.disable_components(tags={"atomic"})
-    else:
-        # Fallback to global (no notification)
-        if enable:
-            mcp.enable(tags={"atomic"})
-        else:
-            mcp.disable(tags={"atomic"})
-    if enable:
-        return """Atomic tools enabled. You can now call these directly:
+    return """Atomic tools available — call these directly:
 
 navvi_open(url, persona?) — Navigate to a URL
 navvi_find(selector, all?, persona?) — Find element by CSS selector → screen-ready (x, y). THE way to get coordinates.
@@ -1823,8 +1809,6 @@ navvi_url(persona?) — Get current page URL
 navvi_creds(action, entry?, field?, persona?) — Gopass credentials: list, get, generate, import, autofill
 
 Workflow: navvi_find(selector) → get (x, y) → navvi_click/navvi_fill at those coords → navvi_screenshot to verify."""
-    else:
-        return "Atomic tools hidden. Use navvi_browse for browser interactions."
 
 
 # --- Journey Tools ---

--- a/src/navvi/__init__.py
+++ b/src/navvi/__init__.py
@@ -62,7 +62,7 @@ from navvi.store import (
 # --- Constants ---
 
 PACKAGE_DIR = os.environ.get("NAVVI_PACKAGE_DIR") or str(Path(__file__).resolve().parent.parent)
-REPO = os.environ.get("NAVVI_REPO") or None
+REPO = os.environ.get("NAVVI_REPO") or "fellowship-dev/navvi"
 MACHINE_TYPE = os.environ.get("NAVVI_MACHINE") or "basicLinux32gb"
 NAVVI_PORT = int(os.environ.get("NAVVI_PORT") or 8024)
 VNC_PORT = int(os.environ.get("NAVVI_VNC_PORT") or 6080)
@@ -768,8 +768,6 @@ async def navvi_start(
         ).format(persona, cname, NAVVI_PORT, health, VNC_PORT)
 
     if mode == "remote":
-        if not REPO:
-            return 'Error: remote mode requires NAVVI_REPO env var (e.g. "fellowship-dev/navvi"). Set it in your MCP config.'
         missing = check_remote_deps()
         if missing:
             return format_missing(missing)

--- a/src/navvi/vision.py
+++ b/src/navvi/vision.py
@@ -20,16 +20,22 @@ VISION_PROMPT = (
     '  "suggested_action": {\n'
     '    "type": "click|fill|press|dismiss|scroll|navigate|abort|done",\n'
     '    "target": "description of what to interact with",\n'
-    '    "value": "text to type, if applicable",\n'
+    '    "text": "text to type (fill actions only)",\n'
+    '    "key": "key to press (press actions only, e.g. Enter, Tab, Escape)",\n'
+    '    "url": "URL to navigate to (navigate actions only)",\n'
     '    "selector_hint": "CSS selector hint, if obvious"\n'
     "  },\n"
     '  "confidence": 0.0 to 1.0\n'
     "}\n"
+    "IMPORTANT: For press actions, always set key to a valid key name (Enter, Tab, Escape, etc.) — never null.\n"
     "Respond with ONLY the JSON object, no explanation."
 )
 
 
-def _build_user_message(instruction: str, url: str, title: str) -> str:
+def _build_user_message(
+    instruction: str, url: str, title: str, steps_history: list = None,
+    viewport_info: dict = None,
+) -> str:
     parts = []
     if instruction:
         parts.append("Goal: " + instruction)
@@ -37,6 +43,26 @@ def _build_user_message(instruction: str, url: str, title: str) -> str:
         parts.append("URL: " + url)
     if title:
         parts.append("Title: " + title)
+    if steps_history:
+        history_lines = []
+        for s in steps_history[-3:]:
+            history_lines.append(
+                "  Step {}: {} -> {} (conf: {})".format(
+                    s.get("step", "?"),
+                    s.get("description", "?"),
+                    s.get("action_taken", "?"),
+                    s.get("confidence", "?"),
+                )
+            )
+        parts.append("Previous steps (do NOT repeat failed/identical actions):\n" + "\n".join(history_lines))
+    if viewport_info:
+        vw = viewport_info.get("viewport_width", 0)
+        vh = viewport_info.get("viewport_height", 0)
+        if vw and vh:
+            parts.append(
+                "Viewport: {}x{}px. Elements with Y > {} are off-screen and need scrolling. "
+                "Only suggest scroll if the target element is NOT visible in the screenshot.".format(vw, vh, vh)
+            )
     parts.append("Analyze this page and suggest the next action to achieve the goal.")
     return "\n".join(parts)
 
@@ -75,6 +101,8 @@ async def analyze(
     instruction: str,
     url: str = "",
     title: str = "",
+    steps_history: list = None,
+    viewport_info: dict = None,
 ) -> dict:
     """Analyze a browser screenshot and return structured classification.
 
@@ -95,7 +123,7 @@ async def analyze(
     # Tier 1: Anthropic API
     if os.environ.get("ANTHROPIC_API_KEY") and screenshot_b64:
         try:
-            result = await _analyze_api(screenshot_b64, instruction, url, title)
+            result = await _analyze_api(screenshot_b64, instruction, url, title, steps_history, viewport_info)
             if result and result.get("page_type"):
                 result["tier_used"] = "api"
                 return result
@@ -105,7 +133,7 @@ async def analyze(
     # Tier 2: claude CLI
     if shutil.which("claude") and screenshot_b64:
         try:
-            result = await _analyze_cli(screenshot_b64, instruction, url, title)
+            result = await _analyze_cli(screenshot_b64, instruction, url, title, steps_history, viewport_info)
             if result and result.get("page_type"):
                 result["tier_used"] = "cli"
                 return result
@@ -117,7 +145,8 @@ async def analyze(
 
 
 async def _analyze_api(
-    screenshot_b64: str, instruction: str, url: str, title: str
+    screenshot_b64: str, instruction: str, url: str, title: str,
+    steps_history: list = None, viewport_info: dict = None,
 ) -> dict:
     """Tier 1: Direct Anthropic API call with Haiku."""
     try:
@@ -126,7 +155,7 @@ async def _analyze_api(
         return {}
 
     client = anthropic.Anthropic()
-    user_text = _build_user_message(instruction, url, title)
+    user_text = _build_user_message(instruction, url, title, steps_history, viewport_info)
 
     message = client.messages.create(
         model="claude-haiku-4-5-20251001",
@@ -156,7 +185,8 @@ async def _analyze_api(
 
 
 async def _analyze_cli(
-    screenshot_b64: str, instruction: str, url: str, title: str
+    screenshot_b64: str, instruction: str, url: str, title: str,
+    steps_history: list = None, viewport_info: dict = None,
 ) -> dict:
     """Tier 2: Shell out to claude -p with the screenshot file."""
     # Save screenshot to temp file
@@ -165,7 +195,7 @@ async def _analyze_cli(
         with open(tmp_path, "wb") as f:
             f.write(base64.b64decode(screenshot_b64))
 
-        user_text = _build_user_message(instruction, url, title)
+        user_text = _build_user_message(instruction, url, title, steps_history, viewport_info)
         prompt = (
             VISION_PROMPT + "\n\n"
             + user_text + "\n\n"


### PR DESCRIPTION
## Summary
- **Atomic tools visible at startup** — Claude Code's deferred tool loading doesn't pick up dynamically revealed tools mid-session, so atomic tools are now always available (fix #45 bug 1)
- **Default NAVVI_REPO** — fallback to `fellowship-dev/navvi` so remote/Codespaces mode works out of the box (fix #45 bug 4)
- **Browse reliability** — split overloaded `value` field into `text`/`key`/`url`, pass step history + viewport to Haiku (fixes stateless loops), stuck detection after 3 identical actions, browser window maximize via xdotool, Outlook signup playbook + dropdown guidance

## Changes
- `src/navvi/__init__.py` — atomic tools enabled at startup, NAVVI_REPO default, stuck detection, action field split
- `src/navvi/vision.py` — step history + viewport context for Haiku, split value→text/key/url in prompt
- `container/start.sh` — xdotool window maximize after Camoufox launch
- `skills/navvi-signup/SKILL.md` — custom dropdown + CAPTCHA guidance
- `skills/navvi-signup/playbooks/outlook.md` — complete Outlook signup playbook

## Test plan
- [ ] Run navvi-runner with Outlook signup — should complete under 15 min
- [ ] Verify atomic tools appear in `ToolSearch` without calling `navvi_atomic` first
- [ ] Verify Codespaces mode starts without `NAVVI_REPO` env var
- [ ] Verify stuck detection breaks browse loop after 3 identical actions

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)