### PR TITLE
Add persona timeline with navvi_milestone tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "navvi"
-version = "3.12.0"
+version = "3.13.0"
 description = "Give your AI agent a real browser identity — MCP server with persistent personas, anti-detection browser, and credential vault."
 readme = "README.md"
 license = "MIT"

--- a/skills/navvi-browse/SKILL.md
+++ b/skills/navvi-browse/SKILL.md
@@ -76,6 +76,20 @@ For every step:
 - **navvi-login** — dedicated login flow with 2FA handling
 - **navvi-signup** — account creation with credential generation
 
+## Milestones
+
+Record milestones for significant moments during browsing — not every click, but meaningful achievements:
+
+- **First visit to a new service**: `navvi_milestone(action="add", event="First visit to {domain}", screenshot=true, tags="first,{service}")`
+- **Posted content** (comment, reply, post): include the FULL text in detail:
+  ```
+  navvi_milestone(action="add", event="Posted on {service}", detail="Subreddit: r/selfhosted\n\nFull text:\n\"Had the same issue with SPF records...\"", url="https://...", tags="{service},comment", screenshot=true)
+  ```
+- **Received interaction** (like, reply, notification): `navvi_milestone(action="add", event="First reply received on {service}", screenshot=true, tags="first,{service},interaction")`
+- **Profile changes**: bio updates, avatar, settings
+
+Always include full content text — this maintains persona voice consistency across sessions.
+
 ## Response Format
 
 When done, return:

--- a/skills/navvi-login/SKILL.md
+++ b/skills/navvi-login/SKILL.md
@@ -33,6 +33,12 @@ If `navvi_login` fails or reports issues:
 - **Other CAPTCHAs** (Arkose/FunCaptcha, hCaptcha): call `navvi_vnc()` — do NOT attempt to solve
 - **Non-standard form**: unlock atomic tools with `navvi_atomic(enable=true)`, then use `navvi_find` + `navvi_fill` for username only. For passwords, use VNC.
 
+### Step 4: Record milestone (first login only)
+If this is the persona's first login to this service, record it:
+```
+mcp__navvi__navvi_milestone(action="add", persona="{persona}", event="First login to {Service}", detail="Logged in as {username}. Landing page: {description of what's visible}.", url="{current_url}", tags="first,{service},login", screenshot=true)
+```
+
 ## Rules
 
 - ALWAYS try `navvi_login` first — only fall back to atomic tools if it fails

--- a/skills/navvi-signup/SKILL.md
+++ b/skills/navvi-signup/SKILL.md
@@ -93,6 +93,13 @@ Screenshot and confirm success. Look for welcome messages, dashboard, confirmati
 mcp__navvi__navvi_account(action="add", persona="{persona}", service="{service}", creds_ref="gopass://navvi/{persona}/{service}")
 ```
 
+### Step 10: Record milestone
+After successful signup, always add a milestone with full details:
+```
+mcp__navvi__navvi_milestone(action="add", persona="{persona}", event="Signed up for {Service}", detail="Username: {username}\nEmail: {email}\n\nSubscriptions/choices made during signup.", url="https://{service}/profile/{username}", tags="first,{service},signup", screenshot=true)
+```
+Include ALL details: username, email, any profile choices, subreddits joined, etc. This builds the persona's life story.
+
 ## Rules
 
 - NEVER type or display passwords — always use gopass via autofill

--- a/src/navvi/__init__.py
+++ b/src/navvi/__init__.py
@@ -57,6 +57,11 @@ from navvi.store import (
     persona_state_summary,
     personas_list_summary,
     ensure_default,
+    add_milestone,
+    list_milestones,
+    delete_milestone,
+    export_timeline,
+    _timeline_dir,
 )
 
 # --- Constants ---
@@ -85,7 +90,7 @@ active_persona: Optional[str] = None
 
 mcp = FastMCP(
     "navvi",
-    version="3.12.0",
+    version="3.13.0",
 )
 
 # Ensure default persona exists on startup
@@ -640,6 +645,137 @@ async def navvi_account(
 
         else:
             return f"Unknown action '{action}'. Valid: add, list, update, delete."
+    except Exception as e:
+        return f"Error: {e}"
+
+
+@mcp.tool(tags={"management"})
+async def navvi_milestone(
+    action: str,
+    persona: str = "default",
+    event: str = "",
+    detail: str = "",
+    url: str = "",
+    tags: str = "",
+    screenshot: bool = False,
+    source: str = "manual",
+    ts: str = "",
+    screenshot_file: str = "",
+    tag: str = "",
+    milestone_id: int = 0,
+    limit: int = 0,
+) -> str:
+    """Curated lifetime timeline for a persona — milestones with evidence. Actions: add, list, export, delete.
+
+    Add: navvi_milestone(action="add", persona="chet", event="Signed up for Reddit", detail="Username: chestertownwilliams. Subscribed to r/selfhosted.", url="https://reddit.com/user/chestertownwilliams", tags="first,reddit,signup", screenshot=true)
+    Import (retroactive): navvi_milestone(action="add", persona="chet", event="Created Outlook account", detail="Email: chester.town.williams@outlook.com", ts="2026-03-27T11:00:00", screenshot_file="/path/to/old-screenshot.png", source="import")
+    List: navvi_milestone(action="list", persona="chet") or navvi_milestone(action="list", persona="chet", tag="reddit", limit=10)
+    Export: navvi_milestone(action="export", persona="chet") — generates full markdown timeline
+    Delete: navvi_milestone(action="delete", milestone_id=3)
+
+    Tags: comma-separated string. Use 'first' tag for firsts (first post, first signup, etc.).
+    Screenshot: if true, captures current browser screen and attaches it. For retroactive imports, use screenshot_file to attach an existing image.
+    Detail: include FULL content — exact post text, comment body, form values. This builds the persona's voice and style for consistency."""
+    import shutil
+    try:
+        tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else []
+
+        if action == "add":
+            if not event:
+                return "Error: event is required for add."
+
+            # Parse optional timestamp for retroactive imports
+            timestamp = None
+            if ts:
+                import datetime
+                for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%d"):
+                    try:
+                        timestamp = datetime.datetime.strptime(ts, fmt).timestamp()
+                        break
+                    except ValueError:
+                        continue
+                if not timestamp:
+                    return f"Error: could not parse ts '{ts}'. Use ISO format: 2026-03-27T11:00:00"
+
+            # Handle screenshot
+            saved_screenshot = ""
+            if screenshot and navvi_api:
+                # Capture current browser screenshot and save persistently
+                try:
+                    import datetime
+                    result = await api_call("GET", "/screenshot")
+                    b64_data = result.get("image", "")
+                    if b64_data:
+                        import base64
+                        dt = datetime.datetime.now()
+                        slug = event.lower().replace(" ", "-")[:40]
+                        slug = "".join(c for c in slug if c.isalnum() or c == "-")
+                        fname = f"{dt.strftime('%Y-%m-%d-%H%M')}-{slug}.png"
+                        dest = _timeline_dir(persona) / fname
+                        dest.write_bytes(base64.b64decode(b64_data))
+                        saved_screenshot = str(dest)
+                except Exception:
+                    pass  # Screenshot is best-effort
+
+            if screenshot_file and os.path.isfile(screenshot_file):
+                # Copy existing screenshot to timeline dir
+                import datetime
+                dt = datetime.datetime.fromtimestamp(timestamp or time.time())
+                slug = event.lower().replace(" ", "-")[:40]
+                slug = "".join(c for c in slug if c.isalnum() or c == "-")
+                ext = os.path.splitext(screenshot_file)[1] or ".png"
+                fname = f"{dt.strftime('%Y-%m-%d-%H%M')}-{slug}{ext}"
+                dest = _timeline_dir(persona) / fname
+                shutil.copy2(screenshot_file, str(dest))
+                saved_screenshot = str(dest)
+
+            m = add_milestone(
+                persona=persona,
+                event=event,
+                detail=detail,
+                url=url,
+                tags=tag_list,
+                screenshot_path=saved_screenshot,
+                source=source,
+                ts=timestamp,
+            )
+            shot_info = f" (screenshot: {saved_screenshot})" if saved_screenshot else ""
+            return f"Milestone #{m['id']} added: {event}{shot_info}"
+
+        elif action == "list":
+            milestones = list_milestones(persona, tag=tag, limit=limit)
+            if not milestones:
+                filter_info = f" with tag '{tag}'" if tag else ""
+                return f"No milestones for '{persona}'{filter_info}."
+            lines = []
+            for m in milestones:
+                from navvi.store import _format_ts
+                tag_str = f" [{', '.join(m['tags'])}]" if m['tags'] else ""
+                shot = " 📸" if m['screenshot_path'] else ""
+                lines.append(f"[{m['id']}] {_format_ts(m['ts'])} — {m['event']}{tag_str}{shot}")
+                if m['detail']:
+                    # Show first 100 chars of detail
+                    preview = m['detail'][:100] + ("..." if len(m['detail']) > 100 else "")
+                    lines.append(f"    {preview}")
+            return "\n".join(lines)
+
+        elif action == "export":
+            md = export_timeline(persona, tag=tag)
+            # Also save to file
+            timeline_path = Path.home() / ".navvi" / persona / "timeline.md"
+            timeline_path.parent.mkdir(parents=True, exist_ok=True)
+            timeline_path.write_text(md)
+            return f"Timeline exported to {timeline_path}\n\n{md}"
+
+        elif action == "delete":
+            if not milestone_id:
+                return "Error: milestone_id is required for delete."
+            if delete_milestone(milestone_id):
+                return f"Milestone {milestone_id} deleted."
+            return f"Milestone {milestone_id} not found."
+
+        else:
+            return f"Unknown action '{action}'. Valid: add, list, export, delete."
     except Exception as e:
         return f"Error: {e}"
 

--- a/src/navvi/store.py
+++ b/src/navvi/store.py
@@ -5,6 +5,7 @@ Schema:
   personas: config + runtime state (name, description, purpose, stealth, locale, timezone, etc.)
   accounts: credential references per persona (service, email, gopass ref, status)
   actions:  append-only action log per persona (timestamped events)
+  milestones: curated lifetime timeline per persona (events with evidence)
 """
 
 import json
@@ -61,6 +62,18 @@ def init_db():
             persona TEXT NOT NULL REFERENCES personas(name) ON DELETE CASCADE,
             action TEXT NOT NULL,
             detail TEXT DEFAULT '',
+            ts REAL NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS milestones (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            persona TEXT NOT NULL REFERENCES personas(name) ON DELETE CASCADE,
+            event TEXT NOT NULL,
+            detail TEXT DEFAULT '',
+            url TEXT DEFAULT '',
+            tags TEXT DEFAULT '[]',
+            screenshot_path TEXT DEFAULT '',
+            source TEXT DEFAULT 'manual',
             ts REAL NOT NULL
         );
     """)
@@ -226,6 +239,111 @@ def get_recent_actions(persona: str, limit: int = 20) -> list:
     return [dict(r) for r in reversed(rows)]
 
 
+# --- Milestones (lifetime timeline) ---
+
+def _timeline_dir(persona: str) -> Path:
+    """Persistent screenshot dir for milestones: ~/.navvi/{persona}/timeline/"""
+    d = Path.home() / ".navvi" / persona / "timeline"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def add_milestone(
+    persona: str,
+    event: str,
+    detail: str = "",
+    url: str = "",
+    tags: list = None,
+    screenshot_path: str = "",
+    source: str = "manual",
+    ts: float = None,
+) -> dict:
+    conn = _connect()
+    now = ts or time.time()
+    tags_json = json.dumps(tags or [])
+    cursor = conn.execute(
+        "INSERT INTO milestones (persona, event, detail, url, tags, screenshot_path, source, ts) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (persona, event, detail, url, tags_json, screenshot_path, source, now),
+    )
+    conn.commit()
+    row = conn.execute("SELECT * FROM milestones WHERE id = ?", (cursor.lastrowid,)).fetchone()
+    conn.close()
+    return _milestone_to_dict(row)
+
+
+def list_milestones(persona: str, tag: str = None, limit: int = 0) -> list:
+    conn = _connect()
+    if tag:
+        rows = conn.execute(
+            "SELECT * FROM milestones WHERE persona = ? AND tags LIKE ? ORDER BY ts",
+            (persona, f'%"{tag}"%'),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            "SELECT * FROM milestones WHERE persona = ? ORDER BY ts",
+            (persona,),
+        ).fetchall()
+    conn.close()
+    results = [_milestone_to_dict(r) for r in rows]
+    if limit > 0:
+        results = results[-limit:]
+    return results
+
+
+def delete_milestone(milestone_id: int) -> bool:
+    conn = _connect()
+    cursor = conn.execute("DELETE FROM milestones WHERE id = ?", (milestone_id,))
+    conn.commit()
+    conn.close()
+    return cursor.rowcount > 0
+
+
+def export_timeline(persona: str, tag: str = None) -> str:
+    """Generate a readable markdown timeline for a persona."""
+    import datetime
+    p = get_persona(persona)
+    if not p:
+        return f"Persona '{persona}' not found."
+
+    milestones = list_milestones(persona, tag=tag)
+    if not milestones:
+        return f"No milestones recorded for '{persona}'."
+
+    desc = f" — {p['description']}" if p['description'] else ""
+    lines = [f"# {persona}{desc} — Timeline", ""]
+
+    current_date = None
+    for m in milestones:
+        dt = datetime.datetime.fromtimestamp(m["ts"])
+        date_str = dt.strftime("%Y-%m-%d")
+        time_str = dt.strftime("%H:%M")
+
+        if date_str != current_date:
+            current_date = date_str
+            lines.append(f"## {date_str}")
+            lines.append("")
+
+        tag_str = " ".join(f"`{t}`" for t in m["tags"]) if m["tags"] else ""
+        lines.append(f"### {time_str} — {m['event']}")
+        if tag_str:
+            lines.append(f"Tags: {tag_str}")
+        if m["url"]:
+            lines.append(f"URL: {m['url']}")
+        if m["detail"]:
+            lines.append(f"\n{m['detail']}")
+        if m["screenshot_path"]:
+            lines.append(f"\n![{m['event']}]({m['screenshot_path']})")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _milestone_to_dict(row) -> dict:
+    d = dict(row)
+    d["tags"] = json.loads(d.get("tags", "[]"))
+    return d
+
+
 # --- State resource (compact YAML-like summary) ---
 
 def persona_state_summary(name: str) -> str:
@@ -255,6 +373,14 @@ def persona_state_summary(name: str) -> str:
             status_suffix = f" ({a['status']})" if a['status'] != 'active' else ""
             creds = f" creds={a['creds_ref']}" if a['creds_ref'] else ""
             lines.append(f"  - {a['service']}: {a['email']}{creds}{status_suffix}")
+
+    milestones = list_milestones(name)
+    if milestones:
+        lines.append("")
+        lines.append(f"milestones: {len(milestones)} recorded")
+        for m in milestones[-5:]:
+            tag_str = f" [{', '.join(m['tags'])}]" if m['tags'] else ""
+            lines.append(f"  - {_format_ts(m['ts'])} — {m['event']}{tag_str}")
 
     actions = get_recent_actions(name, limit=10)
     if actions:


### PR DESCRIPTION
## Summary
- **`navvi_milestone` tool** — curated lifetime timeline per persona with add/list/export/delete actions
- **Persistent screenshots** — saved to `~/.navvi/{persona}/timeline/`, not `/tmp/`
- **Retroactive import** — backfill milestones from past evidence with custom timestamps
- **Content-rich** — full post text, URLs, tags stored for voice/style consistency across sessions
- **Markdown export** — `navvi_milestone(action="export")` generates a readable timeline file
- **Skills updated** — navvi-signup (step 10), navvi-login (step 4), navvi-browse (milestones section) all auto-propose milestones

## Test plan
- [ ] Create a milestone for Chet with screenshot capture
- [ ] Import retroactive milestone with existing screenshot file
- [ ] List milestones filtered by tag
- [ ] Export timeline to markdown
- [ ] Verify `navvi_status` shows milestone count and last 5

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)