### PR TITLE
Multi-tab support for personas

### DIFF
--- a/container/marionette.py
+++ b/container/marionette.py
@@ -136,6 +136,30 @@ class Marionette:
         })
         return result.get("value") if isinstance(result, dict) else result
 
+    def get_window_handle(self):
+        """Get the handle of the current window/tab."""
+        result = self._command("WebDriver:GetWindowHandle")
+        return result.get("value", "") if isinstance(result, dict) else str(result)
+
+    def get_window_handles(self):
+        """Get handles for all open windows/tabs."""
+        result = self._command("WebDriver:GetWindowHandles")
+        return result if isinstance(result, list) else result.get("value", []) if isinstance(result, dict) else []
+
+    def new_window(self, type_hint="tab"):
+        """Open a new window or tab. Returns {"handle": "...", "type": "tab"}."""
+        result = self._command("WebDriver:NewWindow", {"type": type_hint})
+        return result if isinstance(result, dict) else {}
+
+    def switch_to_window(self, handle):
+        """Switch to a window/tab by handle."""
+        return self._command("WebDriver:SwitchToWindow", {"handle": handle})
+
+    def close_window(self):
+        """Close the current window/tab. Returns list of remaining handles."""
+        result = self._command("WebDriver:CloseWindow")
+        return result if isinstance(result, list) else result.get("value", []) if isinstance(result, dict) else []
+
     def execute_async_script(self, script, args=None, timeout_ms=30000):
         """Execute async JavaScript (with callback)."""
         # Set script timeout first

--- a/container/navvi-server.py
+++ b/container/navvi-server.py
@@ -95,6 +95,10 @@ class FindRequest(BaseModel):
     selector: str
     all: bool = False  # return all matches vs just the first
 
+class TabNewRequest(BaseModel):
+    url: str = ""
+
+
 class CredsAutofillRequest(BaseModel):
     entry: str  # gopass entry path, e.g. "navvi/default/tuta"
     username_selector: str = "input[type=email], input[type=text], input[name*=user i], input[name*=email i], input[name*=login i]"
@@ -519,6 +523,84 @@ async def find_element(req: FindRequest):
             el["x"] = el.pop("vx") + offset_x
             el["y"] = el.pop("vy") + offset_y
             return {"ok": True, "found": True, **el}
+    except MarionetteError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# --- Tab management ---
+
+@app.get("/tab/list")
+async def tab_list():
+    """List all tabs with handle, url, and title."""
+    try:
+        m = get_marionette()
+        original_handle = m.get_window_handle()
+        handles = m.get_window_handles()
+        tabs = []
+        for h in handles:
+            m.switch_to_window(h)
+            tabs.append({
+                "handle": h,
+                "url": m.get_url(),
+                "title": m.get_title(),
+            })
+        # Switch back to original tab
+        m.switch_to_window(original_handle)
+        return {"ok": True, "tabs": tabs, "count": len(tabs), "active": original_handle}
+    except MarionetteError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/tab/new")
+async def tab_new(req: TabNewRequest):
+    """Open a new tab, optionally navigate to a URL. Switches to the new tab."""
+    try:
+        m = get_marionette()
+        result = m.new_window("tab")
+        handle = result.get("handle", "")
+        m.switch_to_window(handle)
+        if req.url:
+            m.navigate(req.url)
+            await asyncio.sleep(0.5)
+        url = m.get_url()
+        title = m.get_title()
+        return {"ok": True, "handle": handle, "url": url, "title": title}
+    except MarionetteError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/tab/switch/{handle}")
+async def tab_switch(handle: str):
+    """Switch to a tab by handle. Returns url and title of the switched-to tab."""
+    try:
+        m = get_marionette()
+        m.switch_to_window(handle)
+        url = m.get_url()
+        title = m.get_title()
+        return {"ok": True, "handle": handle, "url": url, "title": title}
+    except MarionetteError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/tab/close/{handle}")
+async def tab_close(handle: str):
+    """Close a tab by handle. Cannot close the last tab."""
+    try:
+        m = get_marionette()
+        handles = m.get_window_handles()
+        if len(handles) <= 1:
+            raise HTTPException(status_code=400, detail="Cannot close the last tab")
+        m.switch_to_window(handle)
+        remaining = m.close_window()
+        # Switch to first remaining tab
+        if remaining:
+            m.switch_to_window(remaining[0])
+            url = m.get_url()
+            title = m.get_title()
+            return {"ok": True, "closed": handle, "active": remaining[0], "url": url, "title": title, "remaining": len(remaining)}
+        return {"ok": True, "closed": handle, "remaining": 0}
+    except HTTPException:
+        raise
     except MarionetteError as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/src/navvi/__init__.py
+++ b/src/navvi/__init__.py
@@ -16,6 +16,9 @@ Element discovery:
 Credentials:
   navvi_creds
 
+Tab management:
+  navvi_tab
+
 Video recording:
   navvi_record_start, navvi_record_stop, navvi_record_gif
 
@@ -1491,6 +1494,78 @@ async def navvi_creds(
             return f"Error: {e}"
 
     return 'Error: action must be "list", "get", "generate", "import", or "autofill".'
+
+
+@mcp.tool(tags={"atomic"})
+async def navvi_tab(
+    action: str,
+    handle: str = "",
+    url: str = "",
+    persona: str = "",
+) -> str:
+    """Manage browser tabs within a persona. Four actions:
+
+    - "list": list all open tabs with handle, url, and title
+    - "new": open a new tab (optionally navigate to url). Switches to the new tab.
+    - "switch": switch to a tab by handle
+    - "close": close a tab by handle (cannot close the last tab)
+    """
+    _, api_base = resolve_persona(persona or None)
+
+    if action == "list":
+        try:
+            result = await api_call("GET", "/tab/list", api_base=api_base)
+            tabs = result.get("tabs", [])
+            active = result.get("active", "")
+            if not tabs:
+                return "No tabs found."
+            output = "Open tabs ({}):\n".format(len(tabs))
+            for t in tabs:
+                marker = " (active)" if t["handle"] == active else ""
+                output += "  [{}]{} {} — {}\n".format(t["handle"], marker, t["title"], t["url"])
+            return output
+        except Exception as e:
+            return "Error: {}".format(e)
+
+    if action == "new":
+        log_action("tab_new", url or "blank")
+        try:
+            body = {"url": url} if url else {}
+            result = await api_call("POST", "/tab/new", body, api_base)
+            return "New tab opened: [{}] {} — {}".format(
+                result.get("handle", ""), result.get("title", ""), result.get("url", "")
+            )
+        except Exception as e:
+            return "Error: {}".format(e)
+
+    if action == "switch":
+        if not handle:
+            return 'Error: "handle" is required for switch action.'
+        try:
+            result = await api_call("POST", "/tab/switch/{}".format(handle), api_base=api_base)
+            return "Switched to tab [{}]: {} — {}".format(
+                handle, result.get("title", ""), result.get("url", "")
+            )
+        except Exception as e:
+            return "Error: {}".format(e)
+
+    if action == "close":
+        if not handle:
+            return 'Error: "handle" is required for close action.'
+        log_action("tab_close", handle)
+        try:
+            result = await api_call("POST", "/tab/close/{}".format(handle), api_base=api_base)
+            return "Closed tab [{}]. Active tab: [{}] {} — {} ({} remaining)".format(
+                handle,
+                result.get("active", ""),
+                result.get("title", ""),
+                result.get("url", ""),
+                result.get("remaining", 0),
+            )
+        except Exception as e:
+            return "Error: {}".format(e)
+
+    return 'Error: action must be "list", "new", "switch", or "close".'
 
 
 @mcp.tool(tags={"recording"})


### PR DESCRIPTION
## Summary
- Add 5 Marionette methods for tab management (new/list/switch/close/get-handle)
- Add 4 HTTP endpoints in navvi-server (/tab/list, /tab/new, /tab/switch, /tab/close)
- Add `navvi_tab` MCP tool with list/new/switch/close actions
- Guard against closing the last tab (Firefox would exit)

Closes #47

## Test plan
- [ ] `navvi_tab(action="list")` returns the default tab
- [ ] `navvi_tab(action="new", url="https://example.com")` opens second tab
- [ ] `navvi_tab(action="list")` shows 2 tabs
- [ ] `navvi_tab(action="switch", handle="...")` switches between tabs
- [ ] `navvi_screenshot` shows correct tab content after switch
- [ ] `navvi_tab(action="close", handle="...")` closes a tab
- [ ] Closing the last tab returns an error (not allowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)