### PR TITLE
Add persona context store for persistent knowledge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "navvi"
-version = "3.18.0"
+version = "3.19.0"
 description = "Give your AI agent a real browser identity — MCP server with persistent personas, anti-detection browser, and credential vault."
 readme = "README.md"
 license = "MIT"

--- a/src/navvi/__init__.py
+++ b/src/navvi/__init__.py
@@ -994,7 +994,7 @@ async def navvi_context(
             entry = update_context(context_id, **kwargs)
             if not entry:
                 return f"Context entry {context_id} not found."
-            return f"Context #{context_id} updated. Digest state reset."
+            return f"Context #{context_id} updated. Will appear as 'updated' in next digest."
 
         elif action == "remove":
             if not context_id:

--- a/src/navvi/__init__.py
+++ b/src/navvi/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Navvi MCP Server v3.3.0 — persistent browser personas via Docker containers.
+Navvi MCP Server v3.19.0 — persistent browser personas via Docker containers.
 
 Lifecycle:
   navvi_start (local|remote), navvi_stop, navvi_status, navvi_list
@@ -77,6 +77,14 @@ from navvi.store import (
     delete_flow as store_delete_flow_fn,
     bump_flow_confidence,
     reset_flow_confidence,
+    add_context,
+    list_context,
+    search_context,
+    update_context,
+    remove_context,
+    get_digest_ingredients,
+    save_digest,
+    get_context_summary,
 )
 
 from navvi.flows import (
@@ -134,6 +142,13 @@ mcp.disable(tags={"recording"})
 def persona_state_resource(name: str) -> str:
     """Current persona state — config, accounts, recent actions."""
     return persona_state_summary(name)
+
+
+@mcp.resource("persona://{name}/context")
+def persona_context_resource(name: str) -> str:
+    """Curated knowledge summary for this persona — what they know."""
+    summary = get_context_summary(name)
+    return summary or f"No context stored for persona '{name}'."
 
 
 @mcp.resource("persona://{name}/accounts")
@@ -903,6 +918,140 @@ async def navvi_milestone(
 
         else:
             return f"Unknown action '{action}'. Valid: add, list, export, brief, delete."
+    except Exception as e:
+        return f"Error: {e}"
+
+
+@mcp.tool()
+async def navvi_context(
+    action: str,
+    persona: str = "default",
+    summary: str = "",
+    source: str = "",
+    tags: str = "",
+    query: str = "",
+    context_id: int = 0,
+) -> str:
+    """Persistent knowledge store for a persona — what they know. Actions: add, list, search, update, remove, digest, save_digest.
+
+    Add: navvi_context(action="add", persona="chet", summary="InboxGuard: email deliverability scanner with SPF/DMARC checks", source="https://inboxguard.me/", tags="competitor,inbox-angel")
+    List: navvi_context(action="list", persona="chet") or navvi_context(action="list", persona="chet", tags="competitor")
+    Search: navvi_context(action="search", persona="chet", query="email deliverability", tags="competitor")
+    Update: navvi_context(action="update", context_id=3, summary="Updated finding", tags="competitor,updated")
+    Remove: navvi_context(action="remove", context_id=3) — soft-deletes, included in next digest
+    Digest: navvi_context(action="digest", persona="chet") — returns current summary + undigested entries for LLM synthesis
+    Save digest: navvi_context(action="save_digest", persona="chet", summary="Synthesized knowledge summary...") — stores digest, marks entries processed
+
+    Milestones = what a persona did. Context = what a persona knows."""
+    try:
+        if action == "add":
+            if not summary:
+                return "Error: summary is required for add."
+            entry = add_context(
+                persona=persona,
+                summary=summary,
+                source=source or None,
+                tags=tags or None,
+            )
+            return f"Context #{entry['id']} added for '{persona}'."
+
+        elif action == "list":
+            entries = list_context(persona, tags=tags or None)
+            if not entries:
+                filter_info = f" with tags '{tags}'" if tags else ""
+                return f"No context entries for '{persona}'{filter_info}."
+            lines = []
+            for e in entries:
+                tag_str = f" [{e['tags']}]" if e['tags'] else ""
+                src = f" ({e['source']})" if e['source'] else ""
+                digested = " ✓" if e['digested_at'] else " •"
+                lines.append(f"[{e['id']}]{digested} {e['summary'][:120]}{tag_str}{src}")
+            return "\n".join(lines)
+
+        elif action == "search":
+            if not query:
+                return "Error: query is required for search."
+            entries = search_context(persona, query, tags=tags or None)
+            if not entries:
+                return f"No matches for '{query}' in '{persona}' context."
+            lines = []
+            for e in entries:
+                tag_str = f" [{e['tags']}]" if e['tags'] else ""
+                src = f" ({e['source']})" if e['source'] else ""
+                lines.append(f"[{e['id']}] {e['summary'][:120]}{tag_str}{src}")
+            return "\n".join(lines)
+
+        elif action == "update":
+            if not context_id:
+                return "Error: context_id is required for update."
+            kwargs = {}
+            if summary:
+                kwargs["summary"] = summary
+            if source:
+                kwargs["source"] = source
+            if tags:
+                kwargs["tags"] = tags
+            entry = update_context(context_id, **kwargs)
+            if not entry:
+                return f"Context entry {context_id} not found."
+            return f"Context #{context_id} updated. Digest state reset."
+
+        elif action == "remove":
+            if not context_id:
+                return "Error: context_id is required for remove."
+            if remove_context(context_id):
+                return f"Context #{context_id} soft-deleted. Will be included in next digest for summary update."
+            return f"Context entry {context_id} not found or already deleted."
+
+        elif action == "digest":
+            ingredients = get_digest_ingredients(persona)
+            if not ingredients["current_summary"] and not ingredients["new_entries"] and not ingredients["updated_entries"] and not ingredients["deleted_entries"]:
+                return f"No context to digest for '{persona}'. Add entries first."
+
+            lines = []
+            if ingredients["current_summary"]:
+                lines.append("## Current Summary")
+                lines.append(ingredients["current_summary"])
+                lines.append("")
+
+            if ingredients["new_entries"]:
+                lines.append(f"## New Entries ({len(ingredients['new_entries'])})")
+                for e in ingredients["new_entries"]:
+                    tag_str = f" [{e['tags']}]" if e['tags'] else ""
+                    src = f"\n  Source: {e['source']}" if e['source'] else ""
+                    lines.append(f"- [{e['id']}] {e['summary']}{tag_str}{src}")
+                lines.append("")
+
+            if ingredients["updated_entries"]:
+                lines.append(f"## Updated Entries ({len(ingredients['updated_entries'])})")
+                for e in ingredients["updated_entries"]:
+                    tag_str = f" [{e['tags']}]" if e['tags'] else ""
+                    lines.append(f"- [{e['id']}] {e['summary']}{tag_str}")
+                lines.append("")
+
+            if ingredients["deleted_entries"]:
+                lines.append(f"## Deleted Entries ({len(ingredients['deleted_entries'])})")
+                for e in ingredients["deleted_entries"]:
+                    lines.append(f"- [{e['id']}] {e['summary']}")
+                lines.append("")
+
+            if not lines:
+                return f"Nothing to digest for '{persona}' — all entries are up to date."
+
+            lines.append("---")
+            lines.append("Synthesize an updated summary incorporating new/updated entries and removing deleted ones. Then call navvi_context(action=\"save_digest\", persona=\"{}\", summary=\"...\")".format(persona))
+            return "\n".join(lines)
+
+        elif action == "save_digest":
+            if not summary:
+                return "Error: summary is required for save_digest."
+            save_digest(persona, summary)
+            # Regenerate brief with new context
+            generate_brief(persona)
+            return f"Digest saved for '{persona}'. Brief regenerated."
+
+        else:
+            return f"Unknown action '{action}'. Valid: add, list, search, update, remove, digest, save_digest."
     except Exception as e:
         return f"Error: {e}"
 

--- a/src/navvi/store.py
+++ b/src/navvi/store.py
@@ -691,7 +691,9 @@ def update_context(context_id: int, **kwargs) -> Optional[dict]:
         conn.close()
         return dict(row) if row else None
     updates["updated_at"] = _now_iso()
-    updates["digested_at"] = None  # Reset digest state on update
+    # Keep digested_at intact — the query `updated_at > digested_at` will
+    # correctly identify this as "updated, needs re-digest". NULLing it would
+    # make it appear as a new entry instead of an updated one.
     set_clause = ", ".join(f"{k} = ?" for k in updates)
     values = list(updates.values()) + [context_id]
     conn.execute(f"UPDATE persona_context SET {set_clause} WHERE id = ?", values)

--- a/src/navvi/store.py
+++ b/src/navvi/store.py
@@ -6,8 +6,10 @@ Schema:
   accounts: credential references per persona (service, email, gopass ref, status)
   actions:  append-only action log per persona (timestamped events)
   milestones: curated lifetime timeline per persona (events with evidence)
+  persona_context: persistent knowledge store per persona (what a persona knows)
 """
 
+import datetime
 import json
 import sqlite3
 import time
@@ -98,6 +100,18 @@ def init_db():
             source TEXT DEFAULT 'manual',
             ts REAL NOT NULL
         );
+
+        CREATE TABLE IF NOT EXISTS persona_context (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            persona TEXT NOT NULL REFERENCES personas(name) ON DELETE CASCADE,
+            summary TEXT NOT NULL,
+            source TEXT,
+            tags TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT,
+            digested_at TEXT,
+            deleted_at TEXT
+        );
     """)
     conn.commit()
     # Migrate: add port columns if missing (existing DBs)
@@ -112,6 +126,12 @@ def init_db():
         conn.execute("SELECT profile FROM personas LIMIT 1")
     except sqlite3.OperationalError:
         conn.execute("ALTER TABLE personas ADD COLUMN profile TEXT DEFAULT ''")
+        conn.commit()
+    # Migrate: add context_summary column if missing (existing DBs)
+    try:
+        conn.execute("SELECT context_summary FROM personas LIMIT 1")
+    except sqlite3.OperationalError:
+        conn.execute("ALTER TABLE personas ADD COLUMN context_summary TEXT DEFAULT ''")
         conn.commit()
     conn.close()
 
@@ -494,6 +514,14 @@ def generate_brief(persona: str) -> str:
                 lines.append(f"> {m['detail'][:500]}")
                 lines.append("")
 
+    # Context — what I know (curated digest)
+    ctx_summary = get_context_summary(persona)
+    if ctx_summary:
+        lines.append("## What I Know")
+        lines.append("")
+        lines.append(ctx_summary)
+        lines.append("")
+
     # Rules
     lines.append("## Rules")
     lines.append("")
@@ -584,8 +612,163 @@ def personas_list_summary() -> str:
 def _format_ts(ts: Optional[float]) -> str:
     if not ts:
         return "never"
-    import datetime
     return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M")
+
+
+# --- Persona Context (knowledge store) ---
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now().isoformat()
+
+
+def add_context(
+    persona: str,
+    summary: str,
+    source: str = None,
+    tags: str = None,
+) -> dict:
+    conn = _connect()
+    now = _now_iso()
+    cursor = conn.execute(
+        "INSERT INTO persona_context (persona, summary, source, tags, created_at) VALUES (?, ?, ?, ?, ?)",
+        (persona, summary, source, tags, now),
+    )
+    conn.commit()
+    row = conn.execute("SELECT * FROM persona_context WHERE id = ?", (cursor.lastrowid,)).fetchone()
+    conn.close()
+    return dict(row)
+
+
+def list_context(persona: str, tags: str = None) -> list:
+    conn = _connect()
+    if tags:
+        tag_list = [t.strip() for t in tags.split(",") if t.strip()]
+        rows = conn.execute(
+            "SELECT * FROM persona_context WHERE persona = ? AND deleted_at IS NULL ORDER BY created_at",
+            (persona,),
+        ).fetchall()
+        conn.close()
+        # Filter: entry must contain at least one of the requested tags
+        results = []
+        for r in rows:
+            entry_tags = set(t.strip() for t in (r["tags"] or "").split(",") if t.strip())
+            if entry_tags & set(tag_list):
+                results.append(dict(r))
+        return results
+    else:
+        rows = conn.execute(
+            "SELECT * FROM persona_context WHERE persona = ? AND deleted_at IS NULL ORDER BY created_at",
+            (persona,),
+        ).fetchall()
+        conn.close()
+        return [dict(r) for r in rows]
+
+
+def search_context(persona: str, query: str, tags: str = None) -> list:
+    conn = _connect()
+    rows = conn.execute(
+        "SELECT * FROM persona_context WHERE persona = ? AND deleted_at IS NULL AND summary LIKE ? ORDER BY created_at",
+        (persona, f"%{query}%"),
+    ).fetchall()
+    conn.close()
+    results = [dict(r) for r in rows]
+    if tags:
+        tag_list = set(t.strip() for t in tags.split(",") if t.strip())
+        results = [
+            r for r in results
+            if set(t.strip() for t in (r["tags"] or "").split(",") if t.strip()) & tag_list
+        ]
+    return results
+
+
+def update_context(context_id: int, **kwargs) -> Optional[dict]:
+    conn = _connect()
+    allowed = {"summary", "source", "tags"}
+    updates = {k: v for k, v in kwargs.items() if k in allowed and v is not None}
+    if not updates:
+        row = conn.execute("SELECT * FROM persona_context WHERE id = ?", (context_id,)).fetchone()
+        conn.close()
+        return dict(row) if row else None
+    updates["updated_at"] = _now_iso()
+    updates["digested_at"] = None  # Reset digest state on update
+    set_clause = ", ".join(f"{k} = ?" for k in updates)
+    values = list(updates.values()) + [context_id]
+    conn.execute(f"UPDATE persona_context SET {set_clause} WHERE id = ?", values)
+    conn.commit()
+    row = conn.execute("SELECT * FROM persona_context WHERE id = ?", (context_id,)).fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def remove_context(context_id: int) -> bool:
+    conn = _connect()
+    now = _now_iso()
+    cursor = conn.execute(
+        "UPDATE persona_context SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL",
+        (now, context_id),
+    )
+    conn.commit()
+    conn.close()
+    return cursor.rowcount > 0
+
+
+def get_digest_ingredients(persona: str) -> dict:
+    """Return current summary + entries needing digest (new, updated, deleted)."""
+    conn = _connect()
+    p = conn.execute("SELECT context_summary FROM personas WHERE name = ?", (persona,)).fetchone()
+    current_summary = (p["context_summary"] or "") if p else ""
+
+    # New: never digested, not deleted
+    new_rows = conn.execute(
+        "SELECT * FROM persona_context WHERE persona = ? AND digested_at IS NULL AND deleted_at IS NULL ORDER BY created_at",
+        (persona,),
+    ).fetchall()
+
+    # Updated: digested_at < updated_at, not deleted
+    updated_rows = conn.execute(
+        "SELECT * FROM persona_context WHERE persona = ? AND digested_at IS NOT NULL AND updated_at IS NOT NULL AND updated_at > digested_at AND deleted_at IS NULL ORDER BY created_at",
+        (persona,),
+    ).fetchall()
+
+    # Deleted: soft-deleted but not yet purged (digested_at doesn't matter)
+    deleted_rows = conn.execute(
+        "SELECT * FROM persona_context WHERE persona = ? AND deleted_at IS NOT NULL ORDER BY created_at",
+        (persona,),
+    ).fetchall()
+
+    conn.close()
+    return {
+        "current_summary": current_summary,
+        "new_entries": [dict(r) for r in new_rows],
+        "updated_entries": [dict(r) for r in updated_rows],
+        "deleted_entries": [dict(r) for r in deleted_rows],
+    }
+
+
+def save_digest(persona: str, summary: str) -> bool:
+    """Store new digest summary, mark entries as digested, hard-delete soft-deleted."""
+    conn = _connect()
+    now = _now_iso()
+    # Update persona summary
+    conn.execute("UPDATE personas SET context_summary = ? WHERE name = ?", (summary, persona))
+    # Mark all active undigested/updated entries as digested
+    conn.execute(
+        "UPDATE persona_context SET digested_at = ? WHERE persona = ? AND deleted_at IS NULL AND (digested_at IS NULL OR (updated_at IS NOT NULL AND updated_at > digested_at))",
+        (now, persona),
+    )
+    # Hard-delete soft-deleted entries
+    conn.execute("DELETE FROM persona_context WHERE persona = ? AND deleted_at IS NOT NULL", (persona,))
+    conn.commit()
+    conn.close()
+    return True
+
+
+def get_context_summary(persona: str) -> str:
+    conn = _connect()
+    row = conn.execute("SELECT context_summary FROM personas WHERE name = ?", (persona,)).fetchone()
+    conn.close()
+    return (row["context_summary"] or "") if row else ""
 
 
 # --- Flows (recipe store) ---

--- a/uv.lock
+++ b/uv.lock
@@ -749,7 +749,7 @@ wheels = [
 
 [[package]]
 name = "navvi"
-version = "3.11.0"
+version = "3.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- Adds persistent per-persona knowledge store (`persona_context` table) with LLM-curated digest workflow
- New `navvi_context` tool with 7 actions: add, list, search, update, remove, digest, save_digest
- MCP resource `persona://{name}/context` exposes curated summary
- `generate_brief()` now includes "What I know" section from digest
- Version bump to 3.19.0

## Design

**Milestones = what a persona did. Context = what a persona knows.**

The calling agent performs LLM synthesis (not Navvi):
1. `navvi_context(action="digest")` → returns current summary + undigested entries
2. Agent synthesizes updated summary
3. `navvi_context(action="save_digest", summary="...")` → stores digest, marks entries processed

Soft-delete on remove ensures deleted knowledge is surfaced in the next digest before hard-deletion.

Full PRD: https://github.com/fellowship-dev/navvi/issues/60#issuecomment-4151837193

## Test plan

- [ ] Create persona, add context entries with tags
- [ ] List/search context entries
- [ ] Update entry and verify `digested_at` resets
- [ ] Remove entry and verify soft-delete
- [ ] Run digest flow (digest → save_digest) and verify summary stored
- [ ] Check `generate_brief()` includes "What I know" section
- [ ] Verify MCP resource returns curated summary
- [ ] Test migration on existing DB (context_summary column added)

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)