### PR TITLE
Add OSS positioning, star CTA, and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to Navvi
+
+Thanks for your interest in contributing!
+
+## Development Setup
+
+```bash
+git clone https://github.com/fellowship-dev/navvi.git
+cd navvi
+
+# Build the container image locally
+docker build -t navvi -f container/Dockerfile container/
+
+# Install the MCP server in editable mode
+pip install -e .
+
+# Run the MCP server (points to local image)
+NAVVI_IMAGE=navvi python -m navvi
+```
+
+Set `NAVVI_IMAGE=navvi` in your `.mcp.json` env to use the locally built image instead of GHCR.
+
+## Reporting Issues
+
+Please [open an issue](https://github.com/fellowship-dev/navvi/issues) with:
+- What you expected to happen
+- What actually happened
+- Steps to reproduce
+
+## Pull Requests
+
+1. Fork the repo
+2. Create a branch (`git checkout -b my-fix`)
+3. Make your changes
+4. Test locally with `NAVVI_IMAGE=navvi`
+5. Open a PR
+
+## Good First Issues
+
+Look for issues labeled [`good first issue`](https://github.com/fellowship-dev/navvi/labels/good%20first%20issue) — these are great starting points.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
   MCP server with persistent personas, anti-detection browser, and credential vault.
   <br />
   Works with Claude Code, Cursor, and other MCP clients.
+  <br />
+  Open-source alternative to <a href="https://www.browserbase.com/">Browserbase</a> and <a href="https://www.hyperbrowser.ai/">Hyperbrowser</a>.
 </p>
 
 <p align="center">
@@ -118,6 +120,12 @@ curl -fsSL https://raw.githubusercontent.com/fellowship-dev/navvi/main/install-c
 - **navvi-browse** &mdash; autonomous web browsing with vision-driven navigation
 - **navvi-login** &mdash; login with stored credentials, handles reCAPTCHA and 2FA
 - **navvi-signup** &mdash; create new accounts with auto-generated credentials
+
+---
+
+If Navvi is useful to you, please [⭐ star the repo](https://github.com/fellowship-dev/navvi) — it helps others discover it.
+
+---
 
 ## Use Cases
 
@@ -266,21 +274,7 @@ Persona config and state live in `~/.navvi/navvi.db`. Each persona's browser pro
 
 ## Contributing
 
-```bash
-git clone https://github.com/fellowship-dev/navvi.git
-cd navvi
-
-# Build the container image locally
-docker build -t navvi -f container/Dockerfile container/
-
-# Install the MCP server in editable mode
-pip install -e .
-
-# Run the MCP server (points to local image)
-NAVVI_IMAGE=navvi python -m navvi
-```
-
-Set `NAVVI_IMAGE=navvi` in your `.mcp.json` env to use the locally built image instead of GHCR.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 
 ## License
 


### PR DESCRIPTION
## Summary

- **OSS positioning**: Added "Open-source alternative to Browserbase and Hyperbrowser" tagline to the README header, right after the MCP clients line
- **Star CTA**: Added a star call-to-action between Quick Start and Use Cases sections
- **CONTRIBUTING.md**: Extracted the Contributing section into a dedicated file with dev setup, issue reporting guidelines, PR workflow, and good-first-issue pointer. README now links to it.

Part of the OSS launch readiness audit. Ref: issue [Fellowship-dev/claude-buddy#49](https://github.com/Fellowship-dev/claude-buddy/issues/49)

## Test plan

- [ ] Verify README renders correctly on GitHub (header tagline, star CTA, contributing link)
- [ ] Verify CONTRIBUTING.md renders correctly and all links work
- [ ] Check that no existing anchor links in the README are broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)