### PR TITLE
feat: add --version flag to CLI

### DIFF
--- a/src/navvi/__init__.py
+++ b/src/navvi/__init__.py
@@ -2790,6 +2790,10 @@ async def navvi_login(service: str, persona: str = "default") -> str:
 
 def main():
     """CLI entry point for `uvx navvi` / `navvi` command."""
+    if "--version" in sys.argv:
+        from importlib.metadata import version
+        print(f"navvi {version('navvi')}")
+        return
     mcp.run(transport="stdio")
 
 


### PR DESCRIPTION
## Summary

- Adds `--version` flag to the `navvi` CLI entry point
- `navvi --version` (and `uvx navvi --version`) now prints `navvi X.Y.Z`
- Uses `importlib.metadata.version()` — reads the installed package version, no duplication

## Test plan

- [ ] `uvx navvi --version` prints `navvi 3.21.0`
- [ ] `navvi --version` prints `navvi 3.21.0`
- [ ] Normal `navvi` (no args) still runs the MCP server as before

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)