### PR TITLE
Add Cursor and Windsurf MCP config examples

### DIFF
--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -1,0 +1,57 @@
+# MCP Client Config Examples
+
+Copy one of these examples into your MCP client config and replace the
+`NAVVI_GPG_PASSPHRASE` placeholder with your own stable passphrase.
+
+## Cursor
+
+For project-specific tools, create `.cursor/mcp.json` in your project and use:
+
+```json
+{
+  "mcpServers": {
+    "navvi": {
+      "command": "uvx",
+      "args": ["navvi@latest"],
+      "env": {
+        "NAVVI_GPG_PASSPHRASE": "pick-any-random-string-here"
+      }
+    }
+  }
+}
+```
+
+The same JSON is available in `cursor.mcp.json`.
+
+## Windsurf
+
+Open Windsurf's raw MCP config at `~/.codeium/windsurf/mcp_config.json` and use:
+
+```json
+{
+  "mcpServers": {
+    "navvi": {
+      "command": "uvx",
+      "args": ["navvi@latest"],
+      "env": {
+        "NAVVI_GPG_PASSPHRASE": "pick-any-random-string-here"
+      }
+    }
+  }
+}
+```
+
+The same JSON is available in `windsurf.mcp_config.json`.
+
+## Notes
+
+- `NAVVI_GPG_PASSPHRASE` enables Navvi's credential vault. Keep it stable for
+  the Docker volume that stores credentials.
+- Restart or refresh MCP servers in your client after changing the config.
+- These examples use `uvx navvi@latest`, matching the top-level README quick
+  start.
+
+References:
+
+- Cursor MCP project configuration: https://docs.cursor.com/advanced/model-context-protocol
+- Windsurf Cascade MCP configuration: https://docs.windsurf.com/windsurf/cascade/mcp

--- a/examples/mcp/cursor.mcp.json
+++ b/examples/mcp/cursor.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "navvi": {
+      "command": "uvx",
+      "args": ["navvi@latest"],
+      "env": {
+        "NAVVI_GPG_PASSPHRASE": "pick-any-random-string-here"
+      }
+    }
+  }
+}

--- a/examples/mcp/windsurf.mcp_config.json
+++ b/examples/mcp/windsurf.mcp_config.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "navvi": {
+      "command": "uvx",
+      "args": ["navvi@latest"],
+      "env": {
+        "NAVVI_GPG_PASSPHRASE": "pick-any-random-string-here"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add copy-paste MCP config examples for Cursor and Windsurf.
- Put the examples under `examples/mcp/` with a short README that names the expected config paths.
- Keep the config shape aligned with the existing Claude Code quick-start (`uvx navvi@latest` + `NAVVI_GPG_PASSPHRASE`).

## Validation

- `python3 -m json.tool` passes for both JSON example files.
- Docs-only change; no package installs, updates, clones, or test-suite runs.

Closes #71.
